### PR TITLE
Fix Chargebee production link

### DIFF
--- a/src/services/subscription/subscription.class.ts
+++ b/src/services/subscription/subscription.class.ts
@@ -43,9 +43,10 @@ export class Subscription extends Service {
     }
     const saved = await super.create(saveData, params)
 
+    const subdomain = process.env.DEPLOYMENT_STAGE === 'production' ? 'kaixr' : 'kaixr-test'
     const returned = {
       subscriptionId: saved.id,
-      paymentUrl: `https://kaixr-test.chargebee.com/hosted_pages/plans/${plan}?subscription[id]=${saved.id as string}&customer[id]=${userId as string}`
+      paymentUrl: `https://${subdomain}.chargebee.com/hosted_pages/plans/${plan}?subscription[id]=${saved.id as string}&customer[id]=${userId as string}`
     }
 
     return returned


### PR DESCRIPTION
Subscription redirect to Chargebee now changes subdomain based on a new ENV_VAR, DEPLOYMENT_STAGE.