### PR TITLE
Setting version number in package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xr3ngine",
   "description": "XR3ngine, built on Node + Feathers + Express + SQL",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "homepage": "",
   "private": true,
   "main": "server",


### PR DESCRIPTION
Main reason is to have a not-ginormous update for Travis to build off of. The GitHub webhook for the monolith pull into dev got a 413 back.