### PR TITLE
Updated service.common.ts to get API server URL from publicRuntimeConfig rather than ENV_VAR.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm install --no-progress --verbose
 COPY . .
 
 RUN /bin/bash -c 'source ./scripts/write_env_stub.sh'
-ENV NEXT_PUBLIC_API_SERVER=http://localhost:3030
+ENV NEXT_PUBLIC_API_SERVER=http://localhost:3333
 
 RUN npm run compile
 

--- a/client/redux/service.common.ts
+++ b/client/redux/service.common.ts
@@ -1,6 +1,8 @@
 import axios from 'axios'
+import getConfig from 'next/dist/next-server/lib/runtime-config'
+const { publicRuntimeConfig } = getConfig()
 
-export const apiUrl = process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_API_SERVER : 'https://localhost:3030'
+export const apiUrl = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.apiServer : 'https://localhost:3030'
 
 export function getAuthHeader () {
   return {}


### PR DESCRIPTION
Updated Dockerfile to write a different port for
NEXT_PUBLIC_API_SERVER to debug where the current URL
is being sourced from.