### PR TITLE
Added feathers-sync.

### DIFF
--- a/ops/xr3ngine/Chart.yaml
+++ b/ops/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.1.5
+version: 1.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
@@ -26,3 +26,8 @@ dependencies:
     version: "1.4.0"
     repository: "https://agones.dev/chart/stable"
     condition: agones.enabled
+
+  - name: redis
+    version: "10.7.13"
+    repository: "https://charts.bitnami.com/bitnami"
+    condition: redis.enabled

--- a/ops/xr3ngine/templates/api-server-deployment.yaml
+++ b/ops/xr3ngine/templates/api-server-deployment.yaml
@@ -58,6 +58,17 @@ spec:
               {{- end }}
             - name: MYSQL_HOST
               value: {{ template "xrsocial.mariadb.host" . }}
+            - name: REDIS_ENABLED
+              value: "true"
+            - name: REDIS_ADDRESS
+              value: "redis-master.default.svc.cluster.local"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-redis
+                  key: redis-password
           ports:
             - name: http
               containerPort: 3030

--- a/ops/xr3ngine/templates/media-server-deployment.yaml
+++ b/ops/xr3ngine/templates/media-server-deployment.yaml
@@ -61,6 +61,17 @@ spec:
               {{- end }}
             - name: MYSQL_HOST
               value: {{ template "xrsocial.mariadb.host" . }}
+            - name: REDIS_ENABLED
+              value: "true"
+            - name: REDIS_ADDRESS
+              value: "redis-master.default.svc.cluster.local"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-redis
+                  key: redis-password
           ports:
             - name: http
               containerPort: 3030

--- a/ops/xr3ngine/values.yaml
+++ b/ops/xr3ngine/values.yaml
@@ -312,3 +312,6 @@ mariadb:
 
 agones:
   enabled: false
+
+redis:
+  enabled: true

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "feathers-seeder": "^2.0.0",
     "feathers-sequelize": "^6.2.0",
     "feathers-swagger": "^1.2.1",
+    "feathers-sync": "^2.1.0",
     "file-loader": "^6.0.0",
     "fs-blob-store": "^5.2.1",
     "glob": "^7.1.6",

--- a/server/app.ts
+++ b/server/app.ts
@@ -17,6 +17,7 @@ import channels from './channels'
 import authentication from './authentication'
 import sequelize from './sequelize'
 import config from './config'
+import sync from 'feathers-sync'
 
 import winston from 'winston'
 // @ts-ignore
@@ -68,6 +69,16 @@ if (config.server.enabled) {
   // Set up Plugins and providers
   app.configure(express.rest())
   app.configure(socketio())
+
+  if (config.redis.enabled === true) {
+    app.configure(sync({
+      uri: config.redis.password != null ? `redis://${config.redis.address}:${config.redis.port}?password=${config.redis.password}` : `redis://${config.redis.address}:${config.redis.port}`
+    }));
+
+    (app as any).sync.ready.then(() => {
+      console.log('Feathers-sync started')
+    })
+  }
 
   // Configure other middleware (see `middleware/index.js`)
   app.configure(middleware)

--- a/server/config.ts
+++ b/server/config.ts
@@ -179,6 +179,13 @@ const chargebee = {
   apiKey: process.env.CHARGEBEE_API_KEY ?? ''
 }
 
+const redis = {
+  enabled: process.env.REDIS_ENABLED ?? false,
+  address: process.env.REDIS_ADDRESS ?? 'localhost',
+  port: process.env.REDIS_PORT ?? '6379',
+  password: process.env.REDIS_PASSWORD ?? null
+}
+
 /**
  * Full config
  */
@@ -190,7 +197,8 @@ const config = {
   client,
   db,
   email,
-  server
+  server,
+  redis
 }
 
 chargebeeInst.configure({

--- a/server/services/accept-invite/accept-invite.service.ts
+++ b/server/services/accept-invite/accept-invite.service.ts
@@ -20,7 +20,6 @@ export default function (app: Application): any {
   // Initialize our service with any options it requires
   app.use('/a-i', new AcceptInvite(options, app), redirect)
 
-  console.log(app.services)
   // Get our initialized service so that we can register hooks
   const service = app.service('a-i')
 


### PR DESCRIPTION
Added feathers-sync to app. Added redis as a dependency of Helm chart.
Added redis configuration options to config file. API and media servers
now source redis password from the secret file its deployment makes.

redis is by default off so as not to trip up any unsuspecting devs.
Use ENV_VAR REDIS_ENABLED=true to enable it.