### PR TITLE
fix: clearEventQueues breaks some event listeners of queries

### DIFF
--- a/packages/engine/src/ecs/classes/System.ts
+++ b/packages/engine/src/ecs/classes/System.ts
@@ -220,17 +220,17 @@ export abstract class System {
     for (const queryName in this.queryResults) {
       const query = this.queryResults[queryName];
       if (query.added) {
-        query.added = []
+        query.added.length = 0
       }
       if (query.removed) {
-        query.removed = []
+        query.removed.length = 0
       }
       if (query.changed) {
         if (Array.isArray(query.changed)) {
-          query.changed = []
+          query.changed.length = 0
         } else {
           for (const name in query.changed as any) {
-            (query.changed as any)[name] = []
+            (query.changed as any)[name].length = 0
           }
         }
       }


### PR DESCRIPTION
function clearEventQueues assignes new array refs, and breaks some event listeners that are using that references