### PR TITLE
Tagging specific version of snapd since default for travis doesn't

### DIFF
--- a/scripts/setup_helm.sh
+++ b/scripts/setup_helm.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 
-sudo apt-get install -y snapd
+sudo apt-get install -y snapd=2.46.1+20.04
 
 sudo snap install kubectl --classic
 


### PR DESCRIPTION
appear to be hosted anymore.