### PR TITLE
Split scripts into separate jobs to avoid the single-job timeout.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,20 +19,24 @@ services:
 before_script:
   - mysql -e 'CREATE DATABASE xr3ngine;'
 
-script:
-  - yarn install
-  - yarn lint
-  - yarn build-docker
+jobs:
+  include:
+    - stage: install
+      script: yarn install
+    - stage: lint
+      script: yarn lint
+    - stage: build-docker
+      script yarn build-docker
 
 before_deploy:
   - scripts/setup_helm.sh
   - scripts/setup_aws.sh $AWS_ACCESS_KEY $AWS_SECRET $AWS_REGION $CLUSTER_NAME
 
 deploy:
-  - provider: script
-    script: bash scripts/publish_dockerhub.sh staging $TRAVIS_COMMIT xr3ngine/xr3ngine && scripts/deploy.sh staging $TRAVIS_COMMIT
-    on:
-      branch: master
+#  - provider: script
+#    script: bash scripts/publish_dockerhub.sh staging $TRAVIS_COMMIT xr3ngine/xr3ngine && scripts/deploy.sh staging $TRAVIS_COMMIT
+#    on:
+#      branch: master
   - provider: script
     script: bash scripts/publish_dockerhub.sh dev $TRAVIS_COMMIT xr3ngine/xr3ngine && scripts/deploy.sh dev $TRAVIS_COMMIT
     on:


### PR DESCRIPTION
Commented out staging deployment.