### PR TITLE
Server build fix

### DIFF
--- a/packages/engine/src/templates/character/components/AnimationManager.ts
+++ b/packages/engine/src/templates/character/components/AnimationManager.ts
@@ -1,10 +1,11 @@
 // Default component, holds data about what behaviors our actor has.
 
 import { Component } from '../../../ecs/classes/Component';
-import { Vector3, Group, Material, AnimationMixer, Mesh, BoxBufferGeometry, AnimationAction, AnimationClip } from 'three';
+import { AnimationClip } from 'three';
 
 import GLTFLoader from 'three-gltf-loader';
 import { isBrowser } from "../../../common/functions/isBrowser";
+import { Types } from '../../../ecs/types/Types';
 
 export class AnimationManager extends Component<AnimationManager> {
 	static instance: AnimationManager
@@ -26,8 +27,8 @@ export class AnimationManager extends Component<AnimationManager> {
 }
 
 // DO TO
-new AnimationManager()
+new AnimationManager();
 
 AnimationManager.schema = {
-	//animations: { type: Types.Ref, default: null }
+	animations: { type: Types.Array, default: [] }
 };

--- a/packages/engine/src/templates/character/components/AnimationManager.ts
+++ b/packages/engine/src/templates/character/components/AnimationManager.ts
@@ -1,25 +1,27 @@
 // Default component, holds data about what behaviors our actor has.
 
 import { Component } from '../../../ecs/classes/Component';
-import { Vector3, Group, Material, AnimationMixer, Mesh, BoxBufferGeometry, AnimationAction } from 'three';
+import { Vector3, Group, Material, AnimationMixer, Mesh, BoxBufferGeometry, AnimationAction, AnimationClip } from 'three';
 
 import GLTFLoader from 'three-gltf-loader';
+import { isBrowser } from "../../../common/functions/isBrowser";
 
 export class AnimationManager extends Component<AnimationManager> {
 	static instance: AnimationManager
 	//public initialized = false
-	animations: any
+	animations: AnimationClip[] = []
 
 	constructor () {
 		super();
 
 		AnimationManager.instance = this;
 
-		 	new GLTFLoader().load('models/avatars/Animation_NoRootMotion.glb', gltf => {
-				this.animations = gltf.animations
-			}
-		)
-
+		if (isBrowser) {
+			new GLTFLoader().load('models/avatars/Animation_NoRootMotion.glb', gltf => {
+					this.animations = gltf.animations;
+				}
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
fix error:
```
ReferenceError: XMLHttpRequest is not defined
    at FileLoader.load (/mnt/c/_WORK/_other/xr3ngine/node_modules/three/build/three.js:36380:5)
    at GLTFLoader.load (/mnt/c/_WORK/_other/xr3ngine/node_modules/three-gltf-loader/index.js:80:11)
    at new AnimationManager (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:28512:43)
    at Object.../engine/src/templates/character/components/AnimationManager.ts (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:28519:1)
    at __webpack_require__ (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:29:31)
    at Object.../engine/src/templates/character/behaviors/initializeCharacter.ts (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:27267:28)
    at __webpack_require__ (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:29:31)
    at Object.../engine/src/templates/character/prefabs/NetworkPlayerCharacter.ts (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:28846:31)
    at __webpack_require__ (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:29:31)
    at Object.../engine/src/templates/networking/DefaultNetworkSchema.ts (/mnt/c/_WORK/_other/xr3ngine/packages/client/.next/server/pages/index.js:31062:34)
```
added isBrowser check before animations loading