### PR TITLE
Fixed incorrect production socket.io path and reverse-proxy.

### DIFF
--- a/packages/client/classes/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/classes/transports/SocketWebRTCClientTransport.ts
@@ -136,8 +136,8 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
         query: query
       });
     } else {
-      this.socket = ioclient(gameserver, {
-        path: `/socket.io/${address as string}/${port.toString()}/realtime`,
+      this.socket = ioclient(`${gameserver}/realtime`, {
+        path: `/socket.io/${address as string}/${port.toString()}`,
         query: query
       });
     }
@@ -150,7 +150,7 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
       const payload = { userId: Network.instance.userId, accessToken: Network.instance.accessToken};
       const { success } = await this.request(MessageTypes.Authorization.toString(), payload);
 
-      if(!success) return console.error("Unable to connect with credentials"); 
+      if(!success) return console.error("Unable to connect with credentials");
       
           // signal that we're a new peer and initialize our
     // mediasoup-client device, if this is our first time connecting
@@ -201,6 +201,10 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
       console.log('Data Producer created');
       // await this.sendCameraStreams();
       if (startVideo === true) this.sendCameraStreams(partyId);
+    });
+    this.socket.on('disconnect', async () => {
+      console.log('Socket received disconnect');
+      // this.socket.close();
     });
     this.socket.on(MessageTypes.WebRTCConsumeData.toString(), this.handleDataConsumerCreation);
     this.socket.on(MessageTypes.WebRTCCreateProducer.toString(), async (socketId, mediaTag, producerId, localPartyId) => {

--- a/packages/client/components/ui/MobileGampad/index.tsx
+++ b/packages/client/components/ui/MobileGampad/index.tsx
@@ -18,7 +18,7 @@ const mapStateToProps = (state: any): any => {
 export type MobileGamepadProps = {
   hovered?: boolean | false;
   layout?: string ;
-  onBoardingStep: number | null;
+  onBoardingStep?: number | null;
 };
 
 export const MobileGamepad: FunctionComponent<MobileGamepadProps> = ({ hovered,layout, onBoardingStep}: MobileGamepadProps) => {

--- a/packages/client/pages/index.tsx
+++ b/packages/client/pages/index.tsx
@@ -13,7 +13,7 @@ import {client} from "../redux/feathers";
 import {connectToInstanceServer, provisionInstanceServer} from "../redux/instanceConnection/service";
 import {selectPartyState} from "../redux/party/selector";
 
-import theme from '../theme'
+import theme from '../theme';
 import { ThemeProvider } from '@material-ui/core';
 
 interface Props {

--- a/packages/ops/configs/nginx-ingress-aws-values.yml
+++ b/packages/ops/configs/nginx-ingress-aws-values.yml
@@ -15,5 +15,6 @@ controller:
       meta.helm.sh/release-namespace: default
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "http"
       service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+      service.beta.kubernetes.io/aws-load-balancer-type: "alb"
       service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "<ACM Certificate ARN for SSL>"
 

--- a/packages/ops/kubernetes/nginx/base/nginx.yaml
+++ b/packages/ops/kubernetes/nginx/base/nginx.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: nginx-ingress
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: nginx-ingress
 rules:

--- a/packages/ops/xr3ngine/Chart.yaml
+++ b/packages/ops/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.0.1
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xr3ngine/templates/api-server-cluster-role-binding.yaml
+++ b/packages/ops/xr3ngine/templates/api-server-cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.api.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "xr3ngine.api.fullname" . }}

--- a/packages/ops/xr3ngine/templates/api-server-cluster-role.yaml
+++ b/packages/ops/xr3ngine/templates/api-server-cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.api.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "xr3ngine.api.fullname" . }}

--- a/packages/ops/xr3ngine/templates/api-server-ingress.yaml
+++ b/packages/ops/xr3ngine/templates/api-server-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "xr3ngine.api.fullname" . -}}
 {{- $svcPort := .Values.api.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/packages/ops/xr3ngine/templates/client-ingress.yaml
+++ b/packages/ops/xr3ngine/templates/client-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "xr3ngine.client.fullname" . -}}
 {{- $svcPort := .Values.client.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/packages/ops/xr3ngine/templates/editor-ingress.yaml
+++ b/packages/ops/xr3ngine/templates/editor-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "xr3ngine.editor.fullname" . -}}
 {{- $svcPort := .Values.editor.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/packages/ops/xr3ngine/templates/game-server-cluster-role-binding.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-cluster-role-binding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gameserver.enabled -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "xr3ngine.gameserver.fullname" . }}

--- a/packages/ops/xr3ngine/templates/game-server-cluster-role.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-cluster-role.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gameserver.enabled }}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "xr3ngine.gameserver.fullname" . }}

--- a/packages/ops/xr3ngine/templates/game-server-fleet-autoscaler.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-fleet-autoscaler.yaml
@@ -27,6 +27,6 @@ spec:
     type: Buffer
     buffer:
       bufferSize: 1
-      minReplicas: 1
+      minReplicas: 2
       maxReplicas: 10
 {{- end }}

--- a/packages/ops/xr3ngine/templates/game-server-ingress.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-ingress.yaml
@@ -1,6 +1,6 @@
 {{- $fullName := include "xr3ngine.gameserver.fullname" . -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -11,14 +11,14 @@ metadata:
     {{- include "xr3ngine.gameserver.labels" . | nindent 4 }}
   annotations:
     nginx.ingress.kubernetes.io/server-snippet: |
-      location ~* /socket.io/([a-zA-Z0-9\.]*)/([a-zA-Z0-9\.]*)/realtime/?$ {
+      location ~* /socket.io/([a-zA-Z0-9\.]*)/([a-zA-Z0-9\.]*)/?$ {
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "Upgrade";
-        proxy_pass http://$1:$2/socket.io/realtime/?$args;
+        proxy_pass http://$1:$2/socket.io/?$args;
       }
 spec:
   rules:
@@ -26,6 +26,9 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: 3030
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 3030

--- a/packages/ops/xr3ngine/templates/media-server-ingress.yaml
+++ b/packages/ops/xr3ngine/templates/media-server-ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "xr3ngine.media.fullname" . -}}
 {{- $svcPort := .Values.media.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}
@@ -33,9 +33,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/packages/server/src/services/instance-provision/instance-provision.class.ts
+++ b/packages/server/src/services/instance-provision/instance-provision.class.ts
@@ -175,7 +175,6 @@ export class InstanceProvision implements ServiceMethods<Data> {
           return getLocalServerIp();
         }
         console.log('Getting free gameserver');
-        console.log((this.app as any).k8AgonesClient);
         const serverResult = await (this.app as any).k8AgonesClient.get('gameservers');
         const readyServers = _.filter(serverResult.items, (server: any) => server.status.state === 'Ready');
         const server = readyServers[Math.floor(Math.random() * readyServers.length)];

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,4 +4,4 @@ set -x
 STAGE=$1
 TAG=$2
 
-helm upgrade --reuse-values --set api.image.tag=$TAG,media.image.tag=$TAG,client.image.tag=$TAG $STAGE xr3ngine/xr3ngine
+helm upgrade --reuse-values --set api.image.tag=$TAG,gameserver.image.tag=$TAG,media.image.tag=$TAG,client.image.tag=$TAG $STAGE xr3ngine/xr3ngine


### PR DESCRIPTION
We're using the '/realtime' namespace, but that should not
go to the path /realtime.

Updated deploy script to properly tag gameserver with new
release.

Updated Ingress and ClusterRoleBinding API versions to full
release, as beta versions are being deprecated.