### PR TITLE
Fixed webpack bug with socket.io trying to serve the client.

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -77,7 +77,7 @@ if (config.server.enabled) {
 
   // Set up Plugins and providers
   app.configure(express.rest());
-  app.configure(socketio((io) => {
+  app.configure(socketio({serveClient: false},(io) => {
     io.use((socket, next) => {
       (socket as any).feathers.socketQuery = socket.handshake.query;
       (socket as any).socketQuery = socket.handshake.query;


### PR DESCRIPTION
Not sure why this was only cropping up recently, but socket.io
normally tries to serve the client, and webpack was building
the server and trying to reference this not-properly-built
library.