### PR TITLE
Fixed issue with editor not running in production.

### DIFF
--- a/packages/client/components/editor/layout/ContextMenu.tsx
+++ b/packages/client/components/editor/layout/ContextMenu.tsx
@@ -1,4 +1,6 @@
 import React from "react";
+// react-contextmenu has a bug when built, and the only viable
+// workaround is to import from the /dist bunled copy of it.
 import {
   connectMenu as _connectMenu,
   ContextMenu as ReactContextMenu,
@@ -6,7 +8,7 @@ import {
   showMenu as _showMenu,
   SubMenu as _SubMenu,
   ContextMenuTrigger as _ContextMenuTrigger
-} from "react-contextmenu";
+} from "react-contextmenu/dist/react-contextmenu";
 import { Theme, ThemeContext } from "./../theme";
 import { createGlobalStyle } from "styled-components";
 export const connectMenu = _connectMenu;


### PR DESCRIPTION
react-contextmenu has a bug when it's webpack'ed up.
Workaround is to import its exports from the /dist
copy.
Tried to implement someone's fork but that didn't work.
Unfortunately, the library has been abandoned, so it
likely will never be fully fixed.