### PR TITLE
Updated editor config to get SERVER_URL and APP_URL from publicRuntimeConfig.

### DIFF
--- a/packages/client/components/editor/configs.ts
+++ b/packages/client/components/editor/configs.ts
@@ -1,4 +1,6 @@
 // import "dotenv";
+import getConfig from 'next/config';
+const { publicRuntimeConfig } = getConfig();
 
 // Read configs from meta tags if available, otherwise use the process.env injected from build.
 const configs = {};
@@ -14,12 +16,12 @@ const get = (configs, key, defaultValue) => {
   }
 };
 
-get(configs, "APP_URL", process.env.APP_URL ?? "https://localhost:3000");
-get(configs, "SERVER_URL", process.env.SERVER_URL ?? "https://localhost:3030");
 get(configs, "GA_TRACKING_ID", process.env.GA_TRACKING_ID);
 get(configs, "SENTRY_DSN", process.env.SENTRY_DSN);
 
 (configs as any).name = (): string => "Scene Editor";
 (configs as any).longName = (): string => "Scene Editor";
+(configs as any).SERVER_URL = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.apiServer : 'https://localhost:3030';
+(configs as any).APP_URL = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.appServer : 'https://localhost:3000';
 
 export default configs;

--- a/packages/engine/tests/input/input-system.test.ts
+++ b/packages/engine/tests/input/input-system.test.ts
@@ -1,5 +1,5 @@
 import { registerSystem } from "../../src/ecs/functions/SystemFunctions";
-import { InputSystem } from "../../src/input/systems/InputSystem";
+import { InputSystem } from "../../src/input/systems/ClientInputSystem";
 import { execute } from "../../src/ecs/functions/EngineFunctions";
 import { addComponent, createEntity, removeComponent } from "../../src/ecs/functions/EntityFunctions";
 import { Input } from "../../src/input/components/Input";

--- a/packages/engine/tests/input/keyboardEvents.test.ts
+++ b/packages/engine/tests/input/keyboardEvents.test.ts
@@ -7,7 +7,7 @@ import { handleKey } from "../../src/input/behaviors/handleKey";
 import { Input } from "../../src/input/components/Input";
 import { LocalInputReceiver } from "../../src/input/components/LocalInputReceiver";
 import { InputSchema } from "../../src/input/interfaces/InputSchema";
-import { InputSystem } from "../../src/input/systems/InputSystem";
+import { InputSystem } from "../../src/input/systems/ClientInputSystem";
 import { DefaultInput } from "../../src/templates/shared/DefaultInput";
 
 let addListenerMock:jest.SpyInstance;

--- a/packages/engine/tests/input/mouseEvents.test.ts
+++ b/packages/engine/tests/input/mouseEvents.test.ts
@@ -1,5 +1,5 @@
 import { registerSystem } from "../../src/ecs/functions/SystemFunctions";
-import { InputSystem } from "../../src/input/systems/InputSystem";
+import { InputSystem } from "../../src/input/systems/ClientInputSystem";
 import { execute } from "../../src/ecs/functions/EngineFunctions";
 import { addComponent, createEntity, removeEntity } from "../../src/ecs/functions/EntityFunctions";
 import { Input } from "../../src/input/components/Input";

--- a/packages/engine/tests/input/touchEvents.test.ts
+++ b/packages/engine/tests/input/touchEvents.test.ts
@@ -1,5 +1,5 @@
 import { registerSystem } from "../../src/ecs/functions/SystemFunctions";
-import { InputSystem } from "../../src/input/systems/InputSystem";
+import { InputSystem } from "../../src/input/systems/ClientInputSystem";
 import { execute } from "../../src/ecs/functions/EngineFunctions";
 import { addComponent, createEntity, removeComponent, removeEntity } from "../../src/ecs/functions/EntityFunctions";
 import { Input } from "../../src/input/components/Input";

--- a/packages/engine/tests/webxr/webxr-input.test.ts
+++ b/packages/engine/tests/webxr/webxr-input.test.ts
@@ -1,6 +1,6 @@
 import "./webxr-input.mock"
 
-import { InputSystem } from "../../src/input/systems/InputSystem"
+import { InputSystem } from "../../src/input/systems/ClientInputSystem"
 import { initializeEngine } from "../../src/initialize"
 import { registerSystem, getSystem } from "../../src/ecs/functions/SystemFunctions"
 

--- a/packages/engine/tests/webxr/webxr-input.xtest.ts
+++ b/packages/engine/tests/webxr/webxr-input.xtest.ts
@@ -1,6 +1,6 @@
 import "./webxr-input.mock"
 
-import { InputSystem } from "../../src/input/systems/InputSystem"
+import { InputSystem } from "../../src/input/systems/ClientInputSystem"
 import { initializeEngine } from "../../src/initialize"
 import { registerSystem, getSystem } from "../../src/ecs/functions/SystemFunctions"
 


### PR DESCRIPTION
Next will not pass ENV_VARs to the browser, and use of NEXT_PUBLIC
variables may not work with pre-built Next apps.