### PR TITLE
fix loading same avatar twice

### DIFF
--- a/packages/engine/src/assets/components/AssetVault.ts
+++ b/packages/engine/src/assets/components/AssetVault.ts
@@ -1,11 +1,12 @@
 import { Component } from '../../ecs/classes/Component';
 import { Types } from '../../ecs/types/Types';
-import { AssetId, AssetMap, AssetUrl } from '../types/AssetTypes';
+import { AssetId, AssetMap, AssetStorage, AssetUrl } from '../types/AssetTypes';
+import { Object3D } from 'three';
 
 // This component should only be used once per game
 export default class AssetVault extends Component<AssetVault> {
   static instance: AssetVault
-  assets: AssetMap
+  assets: AssetStorage
   assetsLoaded!: boolean
 
   constructor () {
@@ -21,6 +22,6 @@ export default class AssetVault extends Component<AssetVault> {
 
   static schema = {
     assetsLoaded: { type: Types.Boolean, default: false },
-    assets: { type: Types.Ref, default: new Map<AssetId, AssetUrl>() }
+    assets: { type: Types.Ref, default: new Map<Object3D, AssetUrl>() }
   }
 }

--- a/packages/engine/src/assets/enums/AssetClass.ts
+++ b/packages/engine/src/assets/enums/AssetClass.ts
@@ -1,9 +1,10 @@
-export const AssetClass = {
-  Model: 0,
-  Image: 1,
-  Video: 2,
-  Audio: 3,
-  Document: 4,
-  Text: 5,
-  Script: 6
-};
+export enum AssetClass {
+  Model,
+  Image,
+  Video,
+  Audio,
+  Document,
+  Text,
+  Script
+}
+

--- a/packages/engine/src/assets/enums/AssetType.ts
+++ b/packages/engine/src/assets/enums/AssetType.ts
@@ -1,19 +1,20 @@
-export const AssetType = {
-  glTF: 0,
-  FBX: 1,
-  OBJ: 2,
-  VRM: 3,
-  PNG: 4,
-  JPEG: 5,
-  MP4: 6,
-  TS: 7,
-  MKV: 8,
-  MP3: 9,
-  OGG: 10,
-  AAC: 11,
-  CSV: 12,
-  PlainText: 13,
-  DOC: 14,
-  XLS: 15,
-  Script: 16
-};
+export enum AssetType {
+  glTF,
+  FBX,
+  OBJ,
+  VRM,
+  PNG,
+  JPEG,
+  MP4,
+  TS,
+  MKV,
+  MP3,
+  OGG,
+  AAC,
+  CSV,
+  PlainText,
+  DOC,
+  XLS,
+  Script
+}
+

--- a/packages/engine/src/assets/functions/LoadingFunctions.ts
+++ b/packages/engine/src/assets/functions/LoadingFunctions.ts
@@ -6,8 +6,10 @@ import { AssetType } from '../enums/AssetType';
 import { AssetId, AssetMap, AssetsLoadedHandler, AssetTypeAlias, AssetUrl } from '../types/AssetTypes';
 import * as FBXLoader from '../loaders/fbx/FBXLoader';
 import { Entity } from '../../ecs/classes/Entity';
+import { clone as SkeletonUtilsClone } from '../../common/functions/SkeletonUtils';
+import { hashResourceString } from './hashResourceString';
 
-// Kicks off an i{terator to load the list of assets and add them to the vault
+// Kicks off an iterator to load the list of assets and add them to the vault
 export function loadAssets (
   assets: AssetMap,
   onAssetLoaded: AssetsLoadedHandler,
@@ -17,18 +19,23 @@ export function loadAssets (
 }
 
 export function loadAsset (url: AssetUrl, entity: Entity, onAssetLoaded: AssetsLoadedHandler): void {
-  if (!AssetVault.instance.assets.has(url)) {
+  const urlHashed = hashResourceString(url);
+  if (AssetVault.instance.assets.has(urlHashed)) {
+    onAssetLoaded(entity, { asset: SkeletonUtilsClone(AssetVault.instance.assets.get(urlHashed)) });
+  } else {
     const loader = getLoaderForAssetType(getAssetType(url));
     if (loader == null) {
       console.error('Loader failed on ', url);
       return;
     }
     loader.load(url, resource => {
-      AssetVault.instance.assets.set(url, resource);
+      if (resource.scene) {
+        // store just scene, no need in all gltf metadata?
+        resource = resource.scene;
+      }
+      AssetVault.instance.assets.set(urlHashed, resource);
       onAssetLoaded(entity, { asset: resource });
     });
-  } else {
-    onAssetLoaded(entity, { asset: AssetVault.instance.assets.get(url) });
   }
 }
 
@@ -43,7 +50,8 @@ function iterateLoadAsset (
     return onAllAssetsLoaded(null, {});
   } else {
     const [{ url }] = current.value;
-    if (!AssetVault.instance.assets.has(url)) {
+    const urlHashed = hashResourceString(url);
+    if (!AssetVault.instance.assets.has(urlHashed)) {
       const loader = getLoaderForAssetType(getAssetType(url));
 
       if (loader == null) {
@@ -56,8 +64,9 @@ function iterateLoadAsset (
           resource.scene.traverse(child => {
           // Do stuff with metadata here
           });
+          resource = resource.scene;
         }
-        AssetVault.instance.assets.set(url, resource);
+        AssetVault.instance.assets.set(urlHashed, resource);
         iterateLoadAsset(iterable, onAssetLoaded, onAllAssetsLoaded);
       });
     } else {
@@ -73,7 +82,7 @@ function getLoaderForAssetType (assetType: AssetTypeAlias): GLTFLoader | any | T
   else if (assetType == AssetType.JPEG) return new TextureLoader();
 }
 
-export function getAssetType (assetFileName) {
+export function getAssetType (assetFileName:string):AssetType {
   if (/\.(?:gltf|glb)$/.test(assetFileName))
     return AssetType.glTF;
   else if (/\.(?:fbx)$/.test(assetFileName))
@@ -88,7 +97,7 @@ export function getAssetType (assetFileName) {
     return null;
 }
 
-export function getAssetClass (assetFileName) {
+export function getAssetClass (assetFileName:string):AssetClass {
   if (/\.(?:gltf|glb|vrm|fbx|obj)$/.test(assetFileName)) {
     return AssetClass.Model;
   } else if (/\.png|jpg|jpeg$/.test(assetFileName)) {

--- a/packages/engine/src/assets/functions/hashResourceString.ts
+++ b/packages/engine/src/assets/functions/hashResourceString.ts
@@ -1,0 +1,10 @@
+export function hashResourceString(str: string): string {
+  let hash = 0;
+  let i = 0;
+  const len = str.length;
+  while (i < len) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i++)) << 0;
+  }
+  // Return the hash plus part of the file name
+  return `${hash}${str.substr(Math.max(str.length - 7, 0))}`;
+}

--- a/packages/engine/src/assets/systems/AssetLoadingSystem.ts
+++ b/packages/engine/src/assets/systems/AssetLoadingSystem.ts
@@ -16,11 +16,12 @@ import { Unload } from '../components/Unload';
 import { AssetClass } from '../enums/AssetClass';
 import { getAssetClass, getAssetType, loadAsset } from '../functions/LoadingFunctions';
 import { ProcessModelAsset } from "../functions/ProcessModelAsset";
+import { Object3D } from 'three';
 
 export default class AssetLoadingSystem extends System {
   updateType = SystemUpdateType.Fixed;
   
-  loaded = new Map<Entity, any>()
+  loaded = new Map<Entity, Object3D>()
   loadingCount = 0;
 
   constructor() {
@@ -61,7 +62,6 @@ export default class AssetLoadingSystem extends System {
 
           if (this.loadingCount === 0) {
             //loading finished
-            console.log('this.loadingCount', this.loadingCount)
             const event = new CustomEvent('scene-loaded', { detail: { loaded: true } });
             document.dispatchEvent(event);
           } else {
@@ -84,13 +84,15 @@ export default class AssetLoadingSystem extends System {
 
       getMutableComponent<AssetLoader>(entity, AssetLoader).loaded = true;
 
-      AssetVault.instance.assets.set(hashResourceString(component.url), asset.scene);
+      // asset is already set into Vault in it's raw unprocessed state
+      // const urlHashed = hashResourceString(component.url);
+      // if (!AssetVault.instance.assets.has(urlHashed)) {
+      //   AssetVault.instance.assets.set(urlHashed, asset);
+      // }
 
       if (component.onLoaded) {
         component.onLoaded(entity, { asset });
       }
-
-      console.log('loaded number ', entity)
     });
 
     this.loaded?.clear();
@@ -105,17 +107,6 @@ export default class AssetLoadingSystem extends System {
       }
     });
   }
-}
-
-export function hashResourceString(str: string): string {
-  let hash = 0;
-  let i = 0;
-  const len = str.length;
-  while (i < len) {
-    hash = ((hash << 5) - hash + str.charCodeAt(i++)) << 0;
-  }
-  // Return the hash plus part of the file name
-  return `${hash}${str.substr(Math.max(str.length - 7, 0))}`;
 }
 
 AssetLoadingSystem.queries = {

--- a/packages/engine/src/assets/types/AssetTypes.ts
+++ b/packages/engine/src/assets/types/AssetTypes.ts
@@ -1,6 +1,9 @@
+import { Object3D } from 'three';
+
 export type AssetId = string | number
 export type AssetsLoadedHandler = (entity, args: { asset? }) => void
 export type AssetMap = Map<AssetId, AssetUrl>
+export type AssetStorage = Map<AssetUrl, Object3D>
 export type AssetUrl = string
 export type AssetTypeAlias = string | number
 export type AssetClassAlias = string | number

--- a/packages/engine/src/common/functions/SkeletonUtils.ts
+++ b/packages/engine/src/common/functions/SkeletonUtils.ts
@@ -1,0 +1,603 @@
+import {
+  AnimationClip,
+  AnimationMixer,
+  Euler,
+  Matrix4, Object3D,
+  Quaternion,
+  QuaternionKeyframeTrack, Skeleton,
+  SkeletonHelper, SkinnedMesh,
+  Vector2,
+  Vector3,
+  VectorKeyframeTrack
+} from "three";
+
+
+  // interface IRetargetOptions {
+  //   preserveMatrix?: boolean;
+  //   preservePosition?: boolean;
+  //   preserveHipPosition?: boolean;
+  //   useTargetMatrix?: boolean;
+  //   hip?: string;
+  //   names?: Record<string, string>;
+  //   offsets?: Record<string, Matrix4>;
+  // }
+  //
+  // export const retarget:( target: Object3D | Skeleton,
+  //                  source: Object3D | Skeleton,
+  //                  options: {} ) => void = function() {
+  //
+  //   const pos = new Vector3(),
+  //     quat = new Quaternion(),
+  //     scale = new Vector3(),
+  //     bindBoneMatrix = new Matrix4(),
+  //     relativeMatrix = new Matrix4(),
+  //     globalMatrix = new Matrix4();
+  //
+  //   return function ( target: Object3D | Skeleton, source: Object3D | Skeleton, options: IRetargetOptions ) {
+  //
+  //     options = options || {};
+  //     options.preserveMatrix = options.preserveMatrix !== undefined ? options.preserveMatrix : true;
+  //     options.preservePosition = options.preservePosition !== undefined ? options.preservePosition : true;
+  //     options.preserveHipPosition = options.preserveHipPosition !== undefined ? options.preserveHipPosition : false;
+  //     options.useTargetMatrix = options.useTargetMatrix !== undefined ? options.useTargetMatrix : false;
+  //     options.hip = options.hip !== undefined ? options.hip : "hip";
+  //     options.names = options.names || {};
+  //
+  //     var sourceBones = source.isObject3D ? source.skeleton.bones : this.getBones( source ),
+  //       bones = target.isObject3D ? target.skeleton.bones : this.getBones( target ),
+  //       bindBones,
+  //       bone, name, boneTo,
+  //       bonesPosition, i;
+  //
+  //     // reset bones
+  //
+  //     if ( target.isObject3D ) {
+  //
+  //       target.skeleton.pose();
+  //
+  //     } else {
+  //
+  //       options.useTargetMatrix = true;
+  //       options.preserveMatrix = false;
+  //
+  //     }
+  //
+  //     if ( options.preservePosition ) {
+  //
+  //       bonesPosition = [];
+  //
+  //       for ( i = 0; i < bones.length; i ++ ) {
+  //
+  //         bonesPosition.push( bones[ i ].position.clone() );
+  //
+  //       }
+  //
+  //     }
+  //
+  //     if ( options.preserveMatrix ) {
+  //
+  //       // reset matrix
+  //
+  //       target.updateMatrixWorld();
+  //
+  //       target.matrixWorld.identity();
+  //
+  //       // reset children matrix
+  //
+  //       for ( i = 0; i < target.children.length; ++ i ) {
+  //
+  //         target.children[ i ].updateMatrixWorld( true );
+  //
+  //       }
+  //
+  //     }
+  //
+  //     if ( options.offsets ) {
+  //
+  //       bindBones = [];
+  //
+  //       for ( i = 0; i < bones.length; ++ i ) {
+  //
+  //         bone = bones[ i ];
+  //         name = options.names[ bone.name ] || bone.name;
+  //
+  //         if ( options.offsets && options.offsets[ name ] ) {
+  //
+  //           bone.matrix.multiply( options.offsets[ name ] );
+  //
+  //           bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
+  //
+  //           bone.updateMatrixWorld();
+  //
+  //         }
+  //
+  //         bindBones.push( bone.matrixWorld.clone() );
+  //
+  //       }
+  //
+  //     }
+  //
+  //     for ( i = 0; i < bones.length; ++ i ) {
+  //
+  //       bone = bones[ i ];
+  //       name = options.names[ bone.name ] || bone.name;
+  //
+  //       boneTo = this.getBoneByName( name, sourceBones );
+  //
+  //       globalMatrix.copy( bone.matrixWorld );
+  //
+  //       if ( boneTo ) {
+  //
+  //         boneTo.updateMatrixWorld();
+  //
+  //         if ( options.useTargetMatrix ) {
+  //
+  //           relativeMatrix.copy( boneTo.matrixWorld );
+  //
+  //         } else {
+  //
+  //           relativeMatrix.getInverse( target.matrixWorld );
+  //           relativeMatrix.multiply( boneTo.matrixWorld );
+  //
+  //         }
+  //
+  //         // ignore scale to extract rotation
+  //
+  //         scale.setFromMatrixScale( relativeMatrix );
+  //         relativeMatrix.scale( scale.set( 1 / scale.x, 1 / scale.y, 1 / scale.z ) );
+  //
+  //         // apply to global matrix
+  //
+  //         globalMatrix.makeRotationFromQuaternion( quat.setFromRotationMatrix( relativeMatrix ) );
+  //
+  //         if ( target.isObject3D ) {
+  //
+  //           var boneIndex = bones.indexOf( bone ),
+  //             wBindMatrix = bindBones ? bindBones[ boneIndex ] : bindBoneMatrix.getInverse( target.skeleton.boneInverses[ boneIndex ] );
+  //
+  //           globalMatrix.multiply( wBindMatrix );
+  //
+  //         }
+  //
+  //         globalMatrix.copyPosition( relativeMatrix );
+  //
+  //       }
+  //
+  //       if ( bone.parent && bone.parent.isBone ) {
+  //
+  //         bone.matrix.getInverse( bone.parent.matrixWorld );
+  //         bone.matrix.multiply( globalMatrix );
+  //
+  //       } else {
+  //
+  //         bone.matrix.copy( globalMatrix );
+  //
+  //       }
+  //
+  //       if ( options.preserveHipPosition && name === options.hip ) {
+  //
+  //         bone.matrix.setPosition( pos.set( 0, bone.position.y, 0 ) );
+  //
+  //       }
+  //
+  //       bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
+  //
+  //       bone.updateMatrixWorld();
+  //
+  //     }
+  //
+  //     if ( options.preservePosition ) {
+  //
+  //       for ( i = 0; i < bones.length; ++ i ) {
+  //
+  //         bone = bones[ i ];
+  //         name = options.names[ bone.name ] || bone.name;
+  //
+  //         if ( name !== options.hip ) {
+  //
+  //           bone.position.copy( bonesPosition[ i ] );
+  //
+  //         }
+  //
+  //       }
+  //
+  //     }
+  //
+  //     if ( options.preserveMatrix ) {
+  //
+  //       // restore matrix
+  //
+  //       target.updateMatrixWorld( true );
+  //
+  //     }
+  //
+  //   };
+  //
+  // }();
+  //
+  //
+  // retargetClip: function ( target, source, clip, options ) {
+  //
+  //   options = options || {};
+  //   options.useFirstFramePosition = options.useFirstFramePosition !== undefined ? options.useFirstFramePosition : false;
+  //   options.fps = options.fps !== undefined ? options.fps : 30;
+  //   options.names = options.names || [];
+  //
+  //   if ( ! source.isObject3D ) {
+  //
+  //     source = this.getHelperFromSkeleton( source );
+  //
+  //   }
+  //
+  //   var numFrames = Math.round( clip.duration * ( options.fps / 1000 ) * 1000 ),
+  //     delta = 1 / options.fps,
+  //     convertedTracks = [],
+  //     mixer = new AnimationMixer( source ),
+  //     bones = this.getBones( target.skeleton ),
+  //     boneDatas = [],
+  //     positionOffset,
+  //     bone, boneTo, boneData,
+  //     name, i, j;
+  //
+  //   mixer.clipAction( clip ).play();
+  //   mixer.update( 0 );
+  //
+  //   source.updateMatrixWorld();
+  //
+  //   for ( i = 0; i < numFrames; ++ i ) {
+  //
+  //     var time = i * delta;
+  //
+  //     this.retarget( target, source, options );
+  //
+  //     for ( j = 0; j < bones.length; ++ j ) {
+  //
+  //       name = options.names[ bones[ j ].name ] || bones[ j ].name;
+  //
+  //       boneTo = this.getBoneByName( name, source.skeleton );
+  //
+  //       if ( boneTo ) {
+  //
+  //         bone = bones[ j ];
+  //         boneData = boneDatas[ j ] = boneDatas[ j ] || { bone: bone };
+  //
+  //         if ( options.hip === name ) {
+  //
+  //           if ( ! boneData.pos ) {
+  //
+  //             boneData.pos = {
+  //               times: new Float32Array( numFrames ),
+  //               values: new Float32Array( numFrames * 3 )
+  //             };
+  //
+  //           }
+  //
+  //           if ( options.useFirstFramePosition ) {
+  //
+  //             if ( i === 0 ) {
+  //
+  //               positionOffset = bone.position.clone();
+  //
+  //             }
+  //
+  //             bone.position.sub( positionOffset );
+  //
+  //           }
+  //
+  //           boneData.pos.times[ i ] = time;
+  //
+  //           bone.position.toArray( boneData.pos.values, i * 3 );
+  //
+  //         }
+  //
+  //         if ( ! boneData.quat ) {
+  //
+  //           boneData.quat = {
+  //             times: new Float32Array( numFrames ),
+  //             values: new Float32Array( numFrames * 4 )
+  //           };
+  //
+  //         }
+  //
+  //         boneData.quat.times[ i ] = time;
+  //
+  //         bone.quaternion.toArray( boneData.quat.values, i * 4 );
+  //
+  //       }
+  //
+  //     }
+  //
+  //     mixer.update( delta );
+  //
+  //     source.updateMatrixWorld();
+  //
+  //   }
+  //
+  //   for ( i = 0; i < boneDatas.length; ++ i ) {
+  //
+  //     boneData = boneDatas[ i ];
+  //
+  //     if ( boneData ) {
+  //
+  //       if ( boneData.pos ) {
+  //
+  //         convertedTracks.push( new VectorKeyframeTrack(
+  //           ".bones[" + boneData.bone.name + "].position",
+  //           boneData.pos.times,
+  //           boneData.pos.values
+  //         ) );
+  //
+  //       }
+  //
+  //       convertedTracks.push( new QuaternionKeyframeTrack(
+  //         ".bones[" + boneData.bone.name + "].quaternion",
+  //         boneData.quat.times,
+  //         boneData.quat.values
+  //       ) );
+  //
+  //     }
+  //
+  //   }
+  //
+  //   mixer.uncacheAction( clip );
+  //
+  //   return new AnimationClip( clip.name, - 1, convertedTracks );
+  //
+  // },
+  //
+  // getHelperFromSkeleton: function ( skeleton ) {
+  //
+  //   var source = new SkeletonHelper( skeleton.bones[ 0 ] );
+  //   source.skeleton = skeleton;
+  //
+  //   return source;
+  //
+  // },
+  //
+  // getSkeletonOffsets: function () {
+  //
+  //   var targetParentPos = new Vector3(),
+  //     targetPos = new Vector3(),
+  //     sourceParentPos = new Vector3(),
+  //     sourcePos = new Vector3(),
+  //     targetDir = new Vector2(),
+  //     sourceDir = new Vector2();
+  //
+  //   return function ( target, source, options ) {
+  //
+  //     options = options || {};
+  //     options.hip = options.hip !== undefined ? options.hip : "hip";
+  //     options.names = options.names || {};
+  //
+  //     if ( ! source.isObject3D ) {
+  //
+  //       source = this.getHelperFromSkeleton( source );
+  //
+  //     }
+  //
+  //     var nameKeys = Object.keys( options.names ),
+  //       nameValues = Object.values( options.names ),
+  //       sourceBones = source.isObject3D ? source.skeleton.bones : this.getBones( source ),
+  //       bones = target.isObject3D ? target.skeleton.bones : this.getBones( target ),
+  //       offsets = [],
+  //       bone, boneTo,
+  //       name, i;
+  //
+  //     target.skeleton.pose();
+  //
+  //     for ( i = 0; i < bones.length; ++ i ) {
+  //
+  //       bone = bones[ i ];
+  //       name = options.names[ bone.name ] || bone.name;
+  //
+  //       boneTo = this.getBoneByName( name, sourceBones );
+  //
+  //       if ( boneTo && name !== options.hip ) {
+  //
+  //         var boneParent = this.getNearestBone( bone.parent, nameKeys ),
+  //           boneToParent = this.getNearestBone( boneTo.parent, nameValues );
+  //
+  //         boneParent.updateMatrixWorld();
+  //         boneToParent.updateMatrixWorld();
+  //
+  //         targetParentPos.setFromMatrixPosition( boneParent.matrixWorld );
+  //         targetPos.setFromMatrixPosition( bone.matrixWorld );
+  //
+  //         sourceParentPos.setFromMatrixPosition( boneToParent.matrixWorld );
+  //         sourcePos.setFromMatrixPosition( boneTo.matrixWorld );
+  //
+  //         targetDir.subVectors(
+  //           new Vector2( targetPos.x, targetPos.y ),
+  //           new Vector2( targetParentPos.x, targetParentPos.y )
+  //         ).normalize();
+  //
+  //         sourceDir.subVectors(
+  //           new Vector2( sourcePos.x, sourcePos.y ),
+  //           new Vector2( sourceParentPos.x, sourceParentPos.y )
+  //         ).normalize();
+  //
+  //         var laterialAngle = targetDir.angle() - sourceDir.angle();
+  //
+  //         var offset = new Matrix4().makeRotationFromEuler(
+  //           new Euler(
+  //             0,
+  //             0,
+  //             laterialAngle
+  //           )
+  //         );
+  //
+  //         bone.matrix.multiply( offset );
+  //
+  //         bone.matrix.decompose( bone.position, bone.quaternion, bone.scale );
+  //
+  //         bone.updateMatrixWorld();
+  //
+  //         offsets[ name ] = offset;
+  //
+  //       }
+  //
+  //     }
+  //
+  //     return offsets;
+  //
+  //   };
+  //
+  // }(),
+  //
+  // renameBones: function ( skeleton, names ) {
+  //
+  //   var bones = this.getBones( skeleton );
+  //
+  //   for ( var i = 0; i < bones.length; ++ i ) {
+  //
+  //     var bone = bones[ i ];
+  //
+  //     if ( names[ bone.name ] ) {
+  //
+  //       bone.name = names[ bone.name ];
+  //
+  //     }
+  //
+  //   }
+  //
+  //   return this;
+  //
+  // },
+  //
+  // getBones: function ( skeleton ) {
+  //
+  //   return Array.isArray( skeleton ) ? skeleton : skeleton.bones;
+  //
+  // },
+  //
+  // getBoneByName: function ( name, skeleton ) {
+  //
+  //   for ( var i = 0, bones = this.getBones( skeleton ); i < bones.length; i ++ ) {
+  //
+  //     if ( name === bones[ i ].name )
+  //
+  //       return bones[ i ];
+  //
+  //   }
+  //
+  // },
+  //
+  // getNearestBone: function ( bone, names ) {
+  //
+  //   while ( bone.isBone ) {
+  //
+  //     if ( names.indexOf( bone.name ) !== - 1 ) {
+  //
+  //       return bone;
+  //
+  //     }
+  //
+  //     bone = bone.parent;
+  //
+  //   }
+  //
+  // },
+  //
+  // findBoneTrackData: function ( name, tracks ) {
+  //
+  //   var regexp = /\[(.*)\]\.(.*)/,
+  //     result = { name: name };
+  //
+  //   for ( var i = 0; i < tracks.length; ++ i ) {
+  //
+  //     // 1 is track name
+  //     // 2 is track type
+  //     var trackData = regexp.exec( tracks[ i ].name );
+  //
+  //     if ( trackData && name === trackData[ 1 ] ) {
+  //
+  //       result[ trackData[ 2 ] ] = i;
+  //
+  //     }
+  //
+  //   }
+  //
+  //   return result;
+  //
+  // },
+  //
+  // getEqualsBonesNames: function ( skeleton, targetSkeleton ) {
+  //
+  //   var sourceBones = this.getBones( skeleton ),
+  //     targetBones = this.getBones( targetSkeleton ),
+  //     bones = [];
+  //
+  //   search : for ( var i = 0; i < sourceBones.length; i ++ ) {
+  //
+  //     var boneName = sourceBones[ i ].name;
+  //
+  //     for ( var j = 0; j < targetBones.length; j ++ ) {
+  //
+  //       if ( boneName === targetBones[ j ].name ) {
+  //
+  //         bones.push( boneName );
+  //
+  //         continue search;
+  //
+  //       }
+  //
+  //     }
+  //
+  //   }
+  //
+  //   return bones;
+  //
+  // }
+
+
+
+  export function clone ( source: Object3D ): Object3D {
+
+    const sourceLookup = new Map();
+    const cloneLookup = new Map();
+
+    const clone = source.clone();
+
+    parallelTraverse( source, clone, ( sourceNode, clonedNode ) => {
+
+      sourceLookup.set( clonedNode, sourceNode );
+      cloneLookup.set( sourceNode, clonedNode );
+
+    } );
+
+    clone.traverse( ( node:unknown ) => {
+
+      if ( ! (node instanceof SkinnedMesh) ) return;
+
+      const clonedMesh = node;
+      const sourceMesh = sourceLookup.get( node );
+      const sourceBones = sourceMesh.skeleton.bones;
+
+      clonedMesh.skeleton = sourceMesh.skeleton.clone();
+      clonedMesh.bindMatrix.copy( sourceMesh.bindMatrix );
+
+      clonedMesh.skeleton.bones = sourceBones.map( ( bone ) => {
+
+        return cloneLookup.get( bone );
+
+      } );
+
+      clonedMesh.bind( clonedMesh.skeleton, clonedMesh.bindMatrix );
+
+    } );
+
+    return clone;
+  }
+
+
+function parallelTraverse( a, b, callback ) {
+
+  callback( a, b );
+
+  for ( let i = 0; i < a.children.length; i ++ ) {
+
+    parallelTraverse( a.children[ i ], b.children[ i ], callback );
+
+  }
+
+}


### PR DESCRIPTION
after first load asset was stored in AssetVault.instance.assets, and later on attempt to load same url again it was returning cached result from AssetVault.instance.assets, problem was that we didn't clone cached resource.

should close #645 