### PR TITLE
Added ability to expand/shrink chat windows.

### DIFF
--- a/packages/client/components/ui/PartyParticipantWindow/PartyParticipantWindow.module.scss
+++ b/packages/client/components/ui/PartyParticipantWindow/PartyParticipantWindow.module.scss
@@ -1,15 +1,13 @@
-$avatar-bg: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiIHN0YW5kYWxvbmU9Im5vIj8+CjwhLS0gQ3JlYXRlZCB3aXRoIElua3NjYXBlIChodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy8pIC0tPgoKPHN2ZwogICB4bWxuczpkYz0iaHR0cDovL3B1cmwub3JnL2RjL2VsZW1lbnRzLzEuMS8iCiAgIHhtbG5zOmNjPSJodHRwOi8vY3JlYXRpdmVjb21tb25zLm9yZy9ucyMiCiAgIHhtbG5zOnJkZj0iaHR0cDovL3d3dy53My5vcmcvMTk5OS8wMi8yMi1yZGYtc3ludGF4LW5zIyIKICAgeG1sbnM6c3ZnPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIKICAgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIgogICB4bWxuczpzb2RpcG9kaT0iaHR0cDovL3NvZGlwb2RpLnNvdXJjZWZvcmdlLm5ldC9EVEQvc29kaXBvZGktMC5kdGQiCiAgIHhtbG5zOmlua3NjYXBlPSJodHRwOi8vd3d3Lmlua3NjYXBlLm9yZy9uYW1lc3BhY2VzL2lua3NjYXBlIgogICB3aWR0aD0iNDgiCiAgIGhlaWdodD0iNDgiCiAgIGlkPSJzdmc0MzQ3IgogICB2ZXJzaW9uPSIxLjEiCiAgIGlua3NjYXBlOnZlcnNpb249IjAuNDguNCByOTkzOSIKICAgc29kaXBvZGk6ZG9jbmFtZT0iYnVkZHkuc3ZnIj4KICA8ZGVmcwogICAgIGlkPSJkZWZzNDM0OSIgLz4KICA8c29kaXBvZGk6bmFtZWR2aWV3CiAgICAgaWQ9ImJhc2UiCiAgICAgcGFnZWNvbG9yPSIjZmZmZmZmIgogICAgIGJvcmRlcmNvbG9yPSIjNjY2NjY2IgogICAgIGJvcmRlcm9wYWNpdHk9IjEuMCIKICAgICBpbmtzY2FwZTpwYWdlb3BhY2l0eT0iMC4wIgogICAgIGlua3NjYXBlOnBhZ2VzaGFkb3c9IjIiCiAgICAgaW5rc2NhcGU6em9vbT0iOCIKICAgICBpbmtzY2FwZTpjeD0iNS4zOTg1Mjk1IgogICAgIGlua3NjYXBlOmN5PSIxMi45NzQ4NTUiCiAgICAgaW5rc2NhcGU6ZG9jdW1lbnQtdW5pdHM9InB4IgogICAgIGlua3NjYXBlOmN1cnJlbnQtbGF5ZXI9ImxheWVyMSIKICAgICBzaG93Z3JpZD0iZmFsc2UiCiAgICAgc2hvd2JvcmRlcj0idHJ1ZSIKICAgICBpbmtzY2FwZTp3aW5kb3ctd2lkdGg9Ijk3OSIKICAgICBpbmtzY2FwZTp3aW5kb3ctaGVpZ2h0PSI4MDkiCiAgICAgaW5rc2NhcGU6d2luZG93LXg9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LXk9IjAiCiAgICAgaW5rc2NhcGU6d2luZG93LW1heGltaXplZD0iMCIgLz4KICA8bWV0YWRhdGEKICAgICBpZD0ibWV0YWRhdGE0MzUyIj4KICAgIDxyZGY6UkRGPgogICAgICA8Y2M6V29yawogICAgICAgICByZGY6YWJvdXQ9IiI+CiAgICAgICAgPGRjOmZvcm1hdD5pbWFnZS9zdmcreG1sPC9kYzpmb3JtYXQ+CiAgICAgICAgPGRjOnR5cGUKICAgICAgICAgICByZGY6cmVzb3VyY2U9Imh0dHA6Ly9wdXJsLm9yZy9kYy9kY21pdHlwZS9TdGlsbEltYWdlIiAvPgogICAgICAgIDxkYzp0aXRsZSAvPgogICAgICA8L2NjOldvcms+CiAgICA8L3JkZjpSREY+CiAgPC9tZXRhZGF0YT4KICA8ZwogICAgIGlua3NjYXBlOmxhYmVsPSJMYXllciAxIgogICAgIGlua3NjYXBlOmdyb3VwbW9kZT0ibGF5ZXIiCiAgICAgaWQ9ImxheWVyMSIKICAgICB0cmFuc2Zvcm09InRyYW5zbGF0ZSgwLC0xMDA0LjM2MjIpIj4KICAgIDxyZWN0CiAgICAgICBzdHlsZT0iZmlsbDpub25lIgogICAgICAgeT0iMTAwNC44OTkyIgogICAgICAgeD0iMS4zNTcxMzQxIgogICAgICAgaGVpZ2h0PSI0Ny4wNzAwNzYiCiAgICAgICB3aWR0aD0iNDQuNjk5NjM4IgogICAgICAgaWQ9InJlY3Q0NDM4IiAvPgogICAgPHBhdGgKICAgICAgIGlua3NjYXBlOmNvbm5lY3Rvci1jdXJ2YXR1cmU9IjAiCiAgICAgICBkPSJtIDI5Ljg3NDA1MiwxMDM3LjgwNzEgYyAtMC4xNzA1MTMsLTEuODgyOCAtMC4xMDUxMDYsLTMuMTk2OCAtMC4xMDUxMDYsLTQuOTE3IDAuODUyNTc2LC0wLjQ0NzQgMi4zODAyMjYsLTMuMjk5NCAyLjYzODMzNCwtNS43MDg5IDAuNjcwMzg5LC0wLjA1NCAxLjcyNzM2MywtMC43MDg5IDIuMDM2ODY1LC0zLjI5MTIgMC4xNjcwMTUsLTEuMzg2MiAtMC40OTYzNzEsLTIuMTY2NSAtMC45MDA0NzMsLTIuNDExOCAxLjA5MDg0OCwtMy4yODA3IDMuMzU2NjIxLC0xMy40Mjk5IC00LjE5MDUxMywtMTQuNDc4OCAtMC43NzY2NzIsLTEuMzY0IC0yLjc2NTY0OCwtMi4wNTQ0IC01LjM1MDI2MiwtMi4wNTQ0IC0xMC4zNDA4MDcsMC4xOTA1IC0xMS41ODgxNTUsNy44MDg4IC05LjMyMTIwNSwxNi41MzMyIC0wLjQwMjk0MywwLjI0NTMgLTEuMDY2MzIyLDEuMDI1NiAtMC45MDA0NzUsMi40MTE4IDAuMzEwNjcyLDIuNTgyMyAxLjM2NjQ3NiwzLjIzNjIgMi4wMzY4NTcsMy4yOTEyIDAuMjU2OTQ5LDIuNDA4MyAxLjg0NTMyMiw1LjI2MTUgMi43MDAyNDMsNS43MDg5IDAsMS43MjAyIDAuMDY0MjYsMy4wMzQyIC0wLjEwNjI3Miw0LjkxNyAtMi4wNDYyMTMsNS41MDA3IC0xNS44NTIyNTAxLDMuOTU2NyAtMTYuNDg5OTM2NiwxNC41NjYxIEggNDYuMzAzMjU0IGMgLTAuNjM2NTI0LC0xMC42MDk0IC0xNC4zODI5OSwtOS4wNjU0IC0xNi40MjkyMDIsLTE0LjU2NjEgeiIKICAgICAgIGlkPSJwYXRoNDQ0MCIKICAgICAgIHN0eWxlPSJvcGFjaXR5OjAuNSIgLz4KICA8L2c+Cjwvc3ZnPgo=");
-
 .party-chat-user {
-    background-image: $avatar-bg;
     background-position: bottom;
     background-repeat: no-repeat;
     background-size: 65% auto;
-    height: 130px;
     margin: 5px;
     overflow: hidden;
-    width: 200px;
     position: relative;
+    height: 65px;
+    width: 100px;
+    border: 3px solid rgba(0,0,0,0);
 
     & > video {
         height: 100%;
@@ -26,66 +24,94 @@ $avatar-bg: url("data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZ
     }
 
     .global-mute {
-        position: absolute;
-        height: 100%;
-        width: 100%;
-        font-size: 24px;
-        color: #5ee0ff;
-        display: flex;
-        justify-content: center;
-        align-items: center;
+        display: none;
     }
+
     .user-controls {
+        display: none;
+    }
+
+    .username {
         position: absolute;
-        bottom: 0;
+        top: 0;
+        text-align: center;
         width: 100%;
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-end;
+    }
 
-        .right-controls {
-            display: flex;
-            flex-direction: column;
-            justify-content: space-between;
-
-            & > .spacer {
-                height: 5px;
-            }
+    &:not(.self-user) {
+        &:hover {
+            cursor: pointer;
+            border: 3px solid #3886a8;
         }
+    }
 
-        button {
-            background-color: white;
-            opacity:40%;
-            z-index: 200;
-            width: 30px;
-            //bottom: 10px;
-            //position: absolute;
-
-            //&.video-control {
-            //    left: 10px;
-            //}
-            //
-            //&.audio-control {
-            //    right: 10px;
-            //}
-
-            &:hover {
-                //background-color: gray;
-                opacity: 60%
-            }
-        }
-
-        & > .audio-slider {
-            width: 60%;
+    &.focused,
+    &.self-user {
+        height: 130px;
+        width: 200px;
+        .global-mute {
+            position: absolute;
+            height: 100%;
+            width: 100%;
+            font-size: 24px;
+            color: #5ee0ff;
             display: flex;
+            justify-content: center;
             align-items: center;
-            z-index: 100;
-            background-color: white;
-            opacity: 40%;
-            border-radius: 15px;
+        }
 
-            & > span {
-                margin: 0 10px;
+        .user-controls {
+            position: absolute;
+            bottom: 0;
+            width: 100%;
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+
+            .right-controls {
+                display: flex;
+                flex-direction: column;
+                justify-content: space-between;
+
+                & > .spacer {
+                    height: 5px;
+                }
+            }
+
+            button {
+                background-color: white;
+                opacity: 40%;
+                z-index: 200;
+                width: 30px;
+                //bottom: 10px;
+                //position: absolute;
+
+                //&.video-control {
+                //    left: 10px;
+                //}
+                //
+                //&.audio-control {
+                //    right: 10px;
+                //}
+
+                &:hover {
+                    //background-color: gray;
+                    opacity: 60%
+                }
+            }
+
+            & > .audio-slider {
+                width: 60%;
+                display: flex;
+                align-items: center;
+                z-index: 100;
+                background-color: white;
+                opacity: 40%;
+                border-radius: 15px;
+
+                & > span {
+                    margin: 0 10px;
+                }
             }
         }
     }

--- a/packages/client/components/ui/PartyVideoWindows/index.tsx
+++ b/packages/client/components/ui/PartyVideoWindows/index.tsx
@@ -30,10 +30,6 @@ const PartyVideoWindows = observer((): JSX.Element => {
     <Grid className={ styles['party-user-container']} container direction="row" wrap="nowrap">
       { parsedConsumers.map(([key, tracks]) => (
         <PartyParticipantWindow
-            containerProportions={{
-              height: 135,
-              width: 240
-            }}
             peerId={tracks.video ? tracks.video._appData.peerId : tracks.audio._appData.peerId}
             key={key}
         />

--- a/packages/client/public/placeholders/default-silhouette.svg
+++ b/packages/client/public/placeholders/default-silhouette.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   id="svg4347"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   sodipodi:docname="buddy.svg">
+  <defs
+     id="defs4349" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8"
+     inkscape:cx="5.3985295"
+     inkscape:cy="12.974855"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     showborder="true"
+     inkscape:window-width="979"
+     inkscape:window-height="809"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata4352">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1004.3622)">
+    <rect
+       style="fill:none"
+       y="1004.8992"
+       x="1.3571341"
+       height="47.070076"
+       width="44.699638"
+       id="rect4438" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 29.874052,1037.8071 c -0.170513,-1.8828 -0.105106,-3.1968 -0.105106,-4.917 0.852576,-0.4474 2.380226,-3.2994 2.638334,-5.7089 0.670389,-0.054 1.727363,-0.7089 2.036865,-3.2912 0.167015,-1.3862 -0.496371,-2.1665 -0.900473,-2.4118 1.090848,-3.2807 3.356621,-13.4299 -4.190513,-14.4788 -0.776672,-1.364 -2.765648,-2.0544 -5.350262,-2.0544 -10.340807,0.1905 -11.588155,7.8088 -9.321205,16.5332 -0.402943,0.2453 -1.066322,1.0256 -0.900475,2.4118 0.310672,2.5823 1.366476,3.2362 2.036857,3.2912 0.256949,2.4083 1.845322,5.2615 2.700243,5.7089 0,1.7202 0.06426,3.0342 -0.106272,4.917 -2.046213,5.5007 -15.8522501,3.9567 -16.4899366,14.5661 H 46.303254 c -0.636524,-10.6094 -14.38299,-9.0654 -16.429202,-14.5661 z"
+       id="path4440"
+       style="opacity:0.5" />
+  </g>
+</svg>


### PR DESCRIPTION
Non-self-user party participants now start off at half size,
with no controls visible. Hovering over the window will
highlight it, and clicking will expand it to full size and
display the controls. Clicking again outside of the controls
will shrink it back down.

Added conditionally truncated usernames to chat windows.

Made video paused image the user's 2D avatar if available,
otherwise it defaults to the Mediasoup silhouette, which
is now included in the 'public' folder instead of being
hard-coded into another file.