### PR TITLE
Updated chart to point to new lagunalabs/xrengine repo.

### DIFF
--- a/packages/ops/xr3ngine/Chart.yaml
+++ b/packages/ops/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.1.3
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xr3ngine/values.yaml
+++ b/packages/ops/xr3ngine/values.yaml
@@ -10,7 +10,7 @@ client:
 
   replicaCount: 1
   image:
-    repository: xr3ngine/xr3ngine
+    repository: lagunalabs/xrengine
     tag: latest
     pullPolicy: IfNotPresent
 
@@ -62,7 +62,7 @@ api:
 
   replicaCount: 1
   image:
-    repository: xr3ngine/xr3ngine
+    repository: lagunalabs/xrengine
     tag: latest
     pullPolicy: IfNotPresent
 
@@ -157,7 +157,7 @@ media:
 
   replicaCount: 1
   image:
-    repository: xr3ngine/xr3ngine
+    repository: lagunalabs/xrengine
     tag: latest
     pullPolicy: IfNotPresent
 
@@ -299,7 +299,7 @@ gameserver:
 
   replicaCount: 1
   image:
-    repository: xr3ngine/xr3ngine
+    repository: lagunalabs/xrengine
     tag: latest
     pullPolicy: IfNotPresent
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,4 +4,4 @@ set -x
 STAGE=$1
 TAG=$2
 
-helm upgrade --reuse-values --set api.image.tag=$TAG,gameserver.image.tag=$TAG,media.image.tag=$TAG,client.image.tag=$TAG $STAGE lagunalabs/xrengine
+helm upgrade --reuse-values --set api.image.tag=$TAG,gameserver.image.tag=$TAG,media.image.tag=$TAG,client.image.tag=$TAG $STAGE xr3ngine/xr3ngine


### PR DESCRIPTION
Switched deploy script back to xr3ngine/xr3ngine since that's
out Helm repo, not our Docker Hub repo.