### PR TITLE
Updated location finding to accomodate adminned locations.

### DIFF
--- a/packages/client/pages/admin/index.tsx
+++ b/packages/client/pages/admin/index.tsx
@@ -1,9 +1,7 @@
-import { ThemeProvider } from '@material-ui/core';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
-import Layout from '../../components/ui/Layout';
-import theme from '../../theme';
+import EmptyLayout from '../../components/ui/Layout/EmptyLayout';
 import AdminConsole from '../../components/ui/Admin';
 import {doLoginAuto} from "../../redux/auth/service";
 
@@ -30,9 +28,9 @@ const AdminConsolePage = (props: Props) => {
 
   return (
       // <ThemeProvider theme={theme}>
-        <Layout pageTitle='Admin Panel'>
+        <EmptyLayout>
             <AdminConsole />
-        </Layout>
+        </EmptyLayout>
       // </ThemeProvider>
   );
 };

--- a/packages/client/redux/admin/service.ts
+++ b/packages/client/redux/admin/service.ts
@@ -85,7 +85,8 @@ export function fetchAdminLocations () {
       query: {
         $sort: {
           name: -1
-        }
+        },
+        adminnedLocations: true
       }
     });
     dispatch(locationsRetrieved(locations));

--- a/packages/client/redux/location/service.ts
+++ b/packages/client/redux/location/service.ts
@@ -16,6 +16,7 @@ export function getLocations(skip?: number, limit?: number) {
         query: {
           $limit: limit != null ? limit : getState().get('locations').get('limit'),
           $skip: skip != null ? skip : getState().get('locations').get('skip'),
+          joinableLocations: true
         }
       });
       dispatch(locationsRetrieved(locationResults));
@@ -46,15 +47,12 @@ export function getLocationByName(locationName: string) {
   return async (dispatch: Dispatch): Promise<any> => {
       const locationResult = await client.service('location').find({
         query: {
-          slugifiedName: locationName
+          slugifiedName: locationName,
+          joinableLocations: true
         }
       }).catch(error => {
         console.log("Couldn't get location by name", error);
       });
-      console.log('Get location by name result:');
-      console.log(locationName);
-      console.log(locationResult);
-      console.log(locationResult.data[0]);
       if (locationResult.total > 0) {
         dispatch(locationRetrieved(locationResult.data[0]));
       }else{

--- a/packages/server/src/models/location.model.ts
+++ b/packages/server/src/models/location.model.ts
@@ -42,6 +42,7 @@ export default (app: Application): any => {
 
   (location as any).associate = (models: any): void => {
     (location as any).hasMany(models.instance);
+    (location as any).hasMany(models.location_admin);
     // (location as any).belongsTo(models.scene, { foreignKey: 'sceneId' }); // scene
     (location as any).belongsToMany(models.user, { through: 'location_admin'});
     (location as any).hasOne(models.location_settings);


### PR DESCRIPTION
Admin panel needed to only get locations the user controls, so
that people couldn't modify or delete someone else's locations.
Updated location 'find' to accept query parameter indicating
whether operation is for joinable locations, adminned locations,
or neither (just get whatever the query says).

Switched Admin page to use EmptyLayout since regular Layout
has all the drawer stuff, including getting joinable locations,
which interferes with adminned locations.