### PR TITLE
initializeNetworkObject with transform

### DIFF
--- a/packages/engine/src/networking/functions/createNetworkPrefab.ts
+++ b/packages/engine/src/networking/functions/createNetworkPrefab.ts
@@ -5,13 +5,16 @@ import { NetworkObject } from '../components/NetworkObject';
 import { Server } from '../components/Server';
 import { Client } from '../components/Client';
 import { NetworkPrefab } from '../interfaces/NetworkPrefab';
+import {Component} from "../../ecs/classes/Component";
 
 /**
  * Instantiate a prefab with network-synced values
  * @param prefab NetworkPrefab to instantiate
  * @param networkId ID of the network object instantiated
+ * @param ownerId
+ * @param override?
  */
-export function createNetworkPrefab(prefab: NetworkPrefab, ownerId, networkId: number): Entity {
+export function createNetworkPrefab(prefab: NetworkPrefab, ownerId, networkId: number, override: NetworkPrefab = null): Entity {
   console.log("createNetworkPrefab");
   const entity = createEntity();
 
@@ -27,58 +30,46 @@ export function createNetworkPrefab(prefab: NetworkPrefab, ownerId, networkId: n
     // Call the behavior with the args
     { action.behavior(entity, action.args); }
   });
+
+  // prepare override map
+  const overrideMaps:{
+    localClientComponents?: Map<Component<any>, Record<string, unknown>>;
+    networkComponents: Map<Component<any>, Record<string, unknown>>;
+    serverComponents: Map<Component<any>, Record<string, unknown>>;
+  } = {
+    localClientComponents: new Map<Component<any>, Record<string, unknown>>(),
+    networkComponents: new Map<Component<any>, Record<string, unknown>>(),
+    serverComponents: new Map<Component<any>, Record<string, unknown>>()
+  };
+
+  if (override) {
+    override.localClientComponents.forEach(component => {
+      overrideMaps.localClientComponents.set(component.type, component.data)
+    })
+    override.networkComponents.forEach(component => {
+      overrideMaps.networkComponents.set(component.type, component.data)
+    })
+    override.serverComponents.forEach(component => {
+      overrideMaps.serverComponents.set(component.type, component.data)
+    })
+  }
+
     // Instantiate local components
   // If this is the local player, spawn the local components (these will not be spawned for other clients)
   // This is good for input, camera, etc
   if (ownerId === Network.instance.userId && prefab.localClientComponents)
   // For each local component on the prefab...
   {
-    prefab.localClientComponents?.forEach(component => {
-      // The component to the entity
-      addComponent(entity, component.type);
-      // If the component has no initialization data, return
-      if (component.data == undefined) return;
-      // Get a mutable reference to the component
-      const addedComponent = getMutableComponent(entity, component.type);
-      // Set initialization data for each key
-      Object.keys(component.data).forEach(initValue => {
-        // Get the component on the entity, and set it to the initializing value from the prefab
-        addedComponent[initValue] = component.data[initValue];
-      });
-    });
+    initComponents(entity, prefab.localClientComponents, overrideMaps.localClientComponents);
   }
   if (Network.instance.transport.isServer)
   // For each server component on the prefab...
   {
-    prefab.serverComponents?.forEach(component => {
-      // The component to the entity
-      addComponent(entity, component.type);
-      // If the component has no initialization data, return
-      if (component.data == undefined) return;
-      // Get a mutable reference to the component
-      const addedComponent = getMutableComponent(entity, component.type);
-      // Set initialization data for each key
-      Object.keys(component.data).forEach(initValue => {
-        // Get the component on the entity, and set it to the initializing value from the prefab
-        addedComponent[initValue] = component.data[initValue];
-      });
-    });
+    initComponents(entity, prefab.serverComponents, overrideMaps.serverComponents);
   }
   // Instantiate network components
   // These will be attached to the entity on all clients
-  prefab.networkComponents?.forEach(component => {
-    // Add the component to our entity
-    addComponent(entity, component.type);
-    // Get a mutable reference to the component
-    if (component.data !== undefined) {
-      const addedComponent = getMutableComponent(entity, component.type);
-      // Set initialization data for each key
-      Object.keys(component.data).forEach(initValue => {
-        // Get the component on the entity, and set it to the initializing value from the prefab
-        addedComponent[initValue] = component.data[initValue];
-      });
-    }
-  });
+  initComponents(entity, prefab.networkComponents, overrideMaps.networkComponents);
     // Call each after create action
     prefab.onAfterCreate?.forEach(action => {
       // If it's a networked behavior, or this is the local player, call it
@@ -87,4 +78,27 @@ export function createNetworkPrefab(prefab: NetworkPrefab, ownerId, networkId: n
       { action.behavior(entity, action.args); }
     });
   return entity;
+}
+
+function initComponents(entity: Entity, components:Array<{ type: any, data?:any }>, override?: Map<any, any>) {
+  components?.forEach(component => {
+    // The component to the entity
+    addComponent(entity, component.type);
+
+    const initData = component.data ?? {};
+    if (override.has(component.type)) {
+      const overrideData = override.get(component.type);
+      Object.keys(overrideData).forEach(key => initData[key] = overrideData[key]);
+    }
+
+    // If the component has no initialization data, return
+    if (typeof initData !== 'object' || Object.keys(initData).length === 0) return;
+    // Get a mutable reference to the component
+    const addedComponent = getMutableComponent(entity, component.type);
+    // Set initialization data for each key
+    Object.keys(initData).forEach(key => {
+      // Get the component on the entity, and set it to the initializing value from the prefab
+      addedComponent[key] = initData[key];
+    });
+  });
 }

--- a/packages/engine/src/networking/functions/initializeNetworkObject.ts
+++ b/packages/engine/src/networking/functions/initializeNetworkObject.ts
@@ -14,13 +14,28 @@ console.log("Initializing network object")
     Network.instance.schema.prefabs[prefabType],
     // Connecting client's ID as a string
     ownerId,
-    networkId
+    networkId,
+    // Initialize with starting position and rotation
+    {
+      localClientComponents: [],
+      networkComponents: [
+        {
+          type: TransformComponent,
+          data: {
+            position: position ? position.clone() : new Vector3(),
+            rotation: rotation ? rotation.clone() : new Quaternion()
+          }
+        }
+      ],
+      serverComponents: []
+    }
   );
 
-  // Initialize with starting position and rotation
-  const transform = getMutableComponent(networkEntity, TransformComponent);
-  transform.position = position ? position: new Vector3();
-  transform.rotation = rotation ? rotation : new Quaternion();
+  // // Initialize with starting position and rotation
+  // const transform = getMutableComponent(networkEntity, TransformComponent);
+  // transform.position = position ? position.clone() : new Vector3();
+  // transform.rotation = rotation ? rotation.clone() : new Quaternion();
+  // (Network.instance as any).transform = transform;
 
   const networkObject = getComponent(networkEntity, NetworkObject);
 

--- a/packages/engine/src/physics/components/CapsuleCollider.ts
+++ b/packages/engine/src/physics/components/CapsuleCollider.ts
@@ -10,6 +10,12 @@ export class CapsuleCollider extends Component<CapsuleCollider>
 	public options: any;
 	public body: Body;
 	// public visual: Mesh;
+	public mass: number;
+	public position: Vec3;
+	public height: number;
+	public radius: number;
+	public segments: number;
+	public friction: number;
 
 	constructor(options: any)
 	{
@@ -67,7 +73,7 @@ export class CapsuleCollider extends Component<CapsuleCollider>
 
 CapsuleCollider.schema = {
 	mass: { type: Types.Number, default: 0 },
-	position: { type: Types.Vector3Type, default: new Vector3( 0, 0, 0 ) },
+	position: { type: Types.Ref, default: new Vec3( 0, 0, 0 ) },
 	height: { type: Types.Number, default: 0.5 },
 	radius: { type: Types.Number, default: 0.3 },
 	segments: { type: Types.Number, default: 8 },

--- a/packages/engine/src/templates/character/behaviors/initializeCharacter.ts
+++ b/packages/engine/src/templates/character/behaviors/initializeCharacter.ts
@@ -14,6 +14,7 @@ import { addState } from "../../../state/behaviors/addState";
 import { State } from "../../../state/components/State";
 import { CharacterStateTypes } from "../CharacterStateTypes";
 import { CharacterComponent } from "../components/CharacterComponent";
+import {TransformComponent} from "../../../transform/components/TransformComponent";
 
 export const initializeCharacter: Behavior = (entity): void => {
 	console.warn("Initializing character for ", entity.id);
@@ -68,11 +69,13 @@ export const initializeCharacter: Behavior = (entity): void => {
 
 	actor.viewVector = new Vector3();
 
+	const transform = getComponent(entity, TransformComponent);
+
 	// Physics
 	// Player Capsule
-	addComponent(entity, CapsuleCollider as any, {
+	addComponent(entity, CapsuleCollider, {
 		mass: actor.actorMass,
-		position: actor.capsulePosition,
+		position: new Vec3( ...transform.position.toArray() ), // actor.capsulePosition ?
 		height: actor.actorHeight,
 		radius: actor.capsuleRadius,
 		segments: actor.capsuleSegments,
@@ -84,7 +87,7 @@ export const initializeCharacter: Behavior = (entity): void => {
 		shape.collisionFilterMask = ~CollisionGroups.TrimeshColliders;
 	});
 	actor.actorCapsule.body.allowSleep = false;
-	actor.actorCapsule.body.position = new Vec3(0, 1, 0);
+	//actor.actorCapsule.body.position = new Vec3(0, 1, 0);
 	// Move actor to different collision group for raycasting
 	actor.actorCapsule.body.collisionFilterGroup = 2;
 

--- a/packages/engine/tests/network/ClientNetworkSystem.test.ts
+++ b/packages/engine/tests/network/ClientNetworkSystem.test.ts
@@ -61,6 +61,7 @@ test("create", () => {
   // TODO: mock initializeNetworkObject
 
   const message: WorldStateInterface = {
+    snapshot: undefined,
     clientsConnected: [],
     clientsDisconnected: [],
     createObjects: [],
@@ -97,8 +98,8 @@ test("create", () => {
 
   const entity = newNetworkObject.entity;
   const transform = getComponent(entity, TransformComponent);
-  expect(transform.position).toMatchObject(expected.position);
   expect(transform.rotation).toMatchObject(expected.rotation);
+  expect(transform.position).toMatchObject(expected.position);
 
   expect(hasComponent(entity, CharacterComponent)).toBeTruthy();
   // expect(hasComponent(entity, LocalInputReceiver)).toBeTruthy();


### PR DESCRIPTION
added override to createNetworkPrefab to be able to override prefab components data on creation, like transform, or avatar id.
may be it's too messy...