### PR TITLE
Fixed app.setup sequelize startup.

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -38,7 +38,7 @@ const server = useSSL
   ? https.createServer(certOptions, app).listen(port)
   : app.listen(port);
 
-// app.setup(server);
+if (useSSL === true) app.setup(server);
 
 process.on('unhandledRejection', (reason, p) =>
   logger.error('Unhandled Rejection at: Promise ', p, reason)


### PR DESCRIPTION
app.listen automatically calls app.setup. Locally, we do
https.createServer(options, app).listen(port), which does not
appear to make the call to app.setup, while production is running
without HTTPS and just does app.listen.

On local, app.setup was only being called once. In production, though,
app.setup was being called twice, which causes issues when trying
to re-seed the database. Made the explicit call to app.setup()
only run if useSSL is true meaning https.createServer() is being called.