### PR TITLE
Added function to clean up gameserver records.

### DIFF
--- a/packages/server/src/app/channels.ts
+++ b/packages/server/src/app/channels.ts
@@ -62,7 +62,20 @@ export default (app: Application): void => {
               await agonesSDK.allocate();
               (app as any).instance = instanceResult;
 
+              if ((app as any).gsSubdomainNumber != null) {
+                const gsSubProvision = await app.service('gameserver-subdomain-provision').find({
+                  query: {
+                    gs_number: (app as any).gsSubdomainNumber
+                  }
+                });
 
+                if (gsSubProvision.total > 0) {
+                  const provision = gsSubProvision.data[0];
+                  await app.service('gameserver-subdomain-provision').patch(provision.id, {
+                    instanceId: instanceResult.id
+                  });
+                }
+              }
 
                 let service, serviceId;
                 const projectRegex = /\/([A-Za-z0-9]+)\/([a-f0-9-]+)$/;

--- a/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
+++ b/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
@@ -11,6 +11,7 @@ import config from '../../config';
 import getLocalServerIp from '../../util/get-local-server-ip';
 import { localConfig } from './config';
 import {
+    cleanupOldGameservers,
     getFreeSubdomain,
     handleConnectToWorld,
     handleDisconnect,
@@ -58,6 +59,7 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
         const localIp = await getLocalServerIp();
         let stringSubdomainNumber, gsResult;
         if (process.env.KUBERNETES === 'true') {
+            await cleanupOldGameservers();
             this.gameServer = await (this.app as any).agonesSDK.getGameServer();
             const name = this.gameServer.objectMeta.name;
             (this.app as any).gsName = name;

--- a/packages/server/src/models/component.model.ts
+++ b/packages/server/src/models/component.model.ts
@@ -35,7 +35,7 @@ export default (app: Application): any => {
         if (!data) {
           return {};
         } else {
-          if (data.match(/^{.*}$/)) {
+          if (typeof data === 'string' && data.match(/^{.*}$/)) {
             return JSON.parse(data);
           } else {
             return data;

--- a/packages/server/src/services/gameserver-subdomain-provision/gameserver-subdomain-provision.service.ts
+++ b/packages/server/src/services/gameserver-subdomain-provision/gameserver-subdomain-provision.service.ts
@@ -15,7 +15,8 @@ declare module '../../declarations' {
 export default (app: Application): any => {
   const options = {
     Model: createModel(app),
-    paginate: app.get('paginate')
+    paginate: app.get('paginate'),
+    multi: true
   };
 
   // Initialize our service with any options it requires


### PR DESCRIPTION
Instance records in the database were sometimes getting left there
if a GS was shut down through abnormal means. This caused problems,
as server provisioning would point clients to a nonexistent GS.
Now, when each GS starts up, it checks to see if each instance
is actually still running, and removes it if not.

Also added better logic to reset subdomain provisioning, which
was rarely getting deallocated before. Additionally, instanceIds
are now recorded with subdomain provision records.