### PR TITLE
Updated provisioning to only use GSes from own release.

### DIFF
--- a/packages/ops/xr3ngine/Chart.yaml
+++ b/packages/ops/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xr3ngine/templates/api-server-deployment.yaml
+++ b/packages/ops/xr3ngine/templates/api-server-deployment.yaml
@@ -69,6 +69,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-redis
                   key: redis-password
+            - name: RELEASE_NAME
+              value: {{ .Release.Name }}
           ports:
             - name: http
               containerPort: 3030

--- a/packages/ops/xr3ngine/templates/client-deployment.yaml
+++ b/packages/ops/xr3ngine/templates/client-deployment.yaml
@@ -39,6 +39,8 @@ spec:
               value: "client"
             - name: KUBERNETES
               value: "true"
+            - name: RELEASE_NAME
+              value: {{ .Release.Name }}
           ports:
             - name: http
               containerPort: 3000

--- a/packages/ops/xr3ngine/templates/game-server-fleet.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-fleet.yaml
@@ -518,6 +518,8 @@ spec:
                     secretKeyRef:
                       name: {{ .Release.Name }}-redis
                       key: redis-password
+                - name: RELEASE_NAME
+                  value: {{ .Release.Name }}
           initContainers:
             - name: init-redis
               image: busybox:1.28

--- a/packages/ops/xr3ngine/templates/media-server-deployment.yaml
+++ b/packages/ops/xr3ngine/templates/media-server-deployment.yaml
@@ -72,6 +72,8 @@ spec:
                 secretKeyRef:
                   name: {{ .Release.Name }}-redis
                   key: redis-password
+            - name: RELEASE_NAME
+              value: {{ .Release.Name }}
           ports:
             - name: http
               containerPort: 3030

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -62,7 +62,8 @@ const server = {
   certPath: path.resolve(path.dirname("./"), process.env.CERT ?? 'certs/cert.pem'),
   keyPath: path.resolve(path.dirname("./"), process.env.KEY ?? 'certs/key.pem'),
   local: process.env.LOCAL === 'true',
-  gameserverContainerPort: process.env.GAMESERVER_CONTAINER_PORT ?? 3030
+  gameserverContainerPort: process.env.GAMESERVER_CONTAINER_PORT ?? 3030,
+  releaseName: process.env.RELEASE_NAME ?? ''
 };
 const obj = process.env.KUBERNETES === 'true' ? { protocol: 'https', hostname: server.hostname }: { protocol: 'https', ...server };
 server.url = process.env.SERVER_URL ?? url.format(obj);
@@ -80,7 +81,8 @@ const client = {
   title: process.env.APP_LOGO ?? 'XR3ngine',
   url: process.env.APP_URL ??
     process.env.APP_HOST ?? // Legacy env var, to deprecate
-    'https://localhost:3000'
+    'https://localhost:3000',
+  releaseName: process.env.RELEASE_NAME ?? ''
 };
 
 const gameserver = {
@@ -89,7 +91,8 @@ const gameserver = {
   rtc_port_block_size: process.env.RTC_PORT_BLOCK_SIZE ? parseInt(process.env.RTC_PORT_BLOCK_SIZE) : 100,
   identifierDigits: 5,
   local: process.env.LOCAL === 'true',
-  domain: process.env.GAMESERVER_DOMAIN ?? 'gameserver.xrengine.io'
+  domain: process.env.GAMESERVER_DOMAIN ?? 'gameserver.xrengine.io',
+  releaseName: process.env.RELEASE_NAME ?? ''
 };
 
 /**


### PR DESCRIPTION
Production environment was erroneously provisioning gameservers
from dev and prod. Added RELEASE_NAME environment variable that
is saved in config.ts. instance-provision now filters out GSes
that are not from the API's release.