### PR TITLE
Updated media start behavior.

### DIFF
--- a/packages/client/classes/transports/SocketWebRTCClientTransport.ts
+++ b/packages/client/classes/transports/SocketWebRTCClientTransport.ts
@@ -9,7 +9,7 @@ import { Transport as MediaSoupTransport } from "mediasoup-client/lib/types";
 import getConfig from "next/config";
 import ioclient from "socket.io-client";
 import store from "../../redux/store";
-import { createDataProducer, endVideoChat, initReceiveTransport, initSendTransport, leave, sendCameraStreams, subscribeToTrack } from "./WebRTCFunctions";
+import { createDataProducer, endVideoChat, initReceiveTransport, initSendTransport, leave, subscribeToTrack } from "./WebRTCFunctions";
 
 const { publicRuntimeConfig } = getConfig();
 const gameserver = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.gameserver : 'https://localhost:3030';
@@ -200,7 +200,6 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
       await createDataProducer();
 
       console.log("Send camera streams called from SocketWebRTCClientTransport");
-      // sendCameraStreams(partyId || 'instance');
     });
   }
 }

--- a/packages/client/components/ui/DrawerControls/index.tsx
+++ b/packages/client/components/ui/DrawerControls/index.tsx
@@ -81,7 +81,6 @@ export const DrawerControls = (props: Props): JSX.Element => {
   };
   return (
     <AppBar className={styles['bottom-appbar']}>
-      { (enableInstanceVideoChat || enablePartyVideoChat) && <NoSSR><VideoChat/></NoSSR> }
       { selfUser.userRole !== 'guest' &&
         <Fab color="primary" aria-label="PersonAdd" onClick={openInvite}>
           <PersonAdd/>

--- a/packages/client/components/ui/MediaIconsBox/index.tsx
+++ b/packages/client/components/ui/MediaIconsBox/index.tsx
@@ -15,75 +15,82 @@ import { observer } from 'mobx-react';
 import styles from './MediaIconsBox.module.scss';
 import store from "../../../redux/store";
 import { MediaStreamComponent } from "@xr3ngine/engine/src/networking/components/MediaStreamComponent";
-import { endVideoChat, pauseProducer, resumeProducer, sendCameraStreams} from "../../../classes/transports/WebRTCFunctions";
+import {
+    configureMediaTransports,
+    createCamAudioProducer,
+    createCamVideoProducer,
+    endVideoChat,
+    pauseProducer,
+    resumeProducer
+} from "../../../classes/transports/WebRTCFunctions";
 import { selectAuthState } from "../../../redux/auth/selector";
 import { selectLocationState } from "../../../redux/location/selector";
 
 
 const mapStateToProps = (state: any): any => {
-  return {   
-    onBoardingStep: selectAppOnBoardingStep(state),
-    authState: selectAuthState(state),
-    locationState: selectLocationState(state)
-  };
+    return {
+        onBoardingStep: selectAppOnBoardingStep(state),
+        authState: selectAuthState(state),
+        locationState: selectLocationState(state)
+    };
 };
 
 const MediaIconsBox = observer((props) =>{
-  const { onBoardingStep, authState, locationState } = props;
+    const { onBoardingStep, authState, locationState } = props;
 
-  const user = authState.get('user');
-  const currentLocation = locationState.get('currentLocation').get('location');
-  
-  const checkMediaStream = async (type) =>{
-    if(!MediaStreamComponent?.instance?.mediaStream){      
-      await sendCameraStreams(currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId);
-      switch(type){
-        case 'mic': MediaStreamComponent.instance.toggleVideoPaused(); 
-                    await pauseProducer(MediaStreamComponent.instance.camVideoProducer); 
-                    break;
-        case 'cam': MediaStreamComponent.instance.toggleAudioPaused(); 
-                    await pauseProducer(MediaStreamComponent.instance.camAudioProducer); 
-                    break;
-      }
-    }
-  };
+    const user = authState.get('user');
+    const currentLocation = locationState.get('currentLocation').get('location');
 
-  const checkEndVideoChat = async () =>{
-    if(MediaStreamComponent?.instance.audioPaused && MediaStreamComponent?.instance.videoPaused){
-      await endVideoChat({});
-    }
-  };
-  const handleMicClick = async () =>{
-    if(onBoardingStep === generalStateList.TUTOR_UNMUTE){
-      store.dispatch(setAppOnBoardingStep(generalStateList.TUTOR_END));
-      return;
-    } 
-    await checkMediaStream('mic');
-    const audioPaused = MediaStreamComponent.instance.toggleAudioPaused();
-    if (audioPaused === true) await pauseProducer(MediaStreamComponent.instance.camAudioProducer);
-      else await resumeProducer(MediaStreamComponent.instance.camAudioProducer);
-    checkEndVideoChat();
-  };
+    const checkMediaStream = async (partyId: string) => {
+        if (!MediaStreamComponent?.instance?.mediaStream)
+            await configureMediaTransports(partyId);
+    };
 
-  const handleCamClick = async () => {
-    await checkMediaStream('cam');
-    const videoPaused = MediaStreamComponent.instance.toggleVideoPaused();
-    if (videoPaused === true) await pauseProducer(MediaStreamComponent.instance.camVideoProducer);
-      else await resumeProducer(MediaStreamComponent.instance.camVideoProducer);
-    checkEndVideoChat();
-  };
+    const checkEndVideoChat = async () =>{
+        if((MediaStreamComponent?.instance?.audioPaused || MediaStreamComponent?.instance?.camAudioProducer == null) && (MediaStreamComponent?.instance?.videoPaused || MediaStreamComponent?.instance?.camVideoProducer == null)) {
+            await endVideoChat({});
+        }
+    };
+    const handleMicClick = async () => {
+        if(onBoardingStep === generalStateList.TUTOR_UNMUTE){
+            store.dispatch(setAppOnBoardingStep(generalStateList.TUTOR_END));
+            return;
+        }
+        const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId;
+        await checkMediaStream(partyId);
 
-  const audioPaused = MediaStreamComponent?.instance?.mediaStream === null || MediaStreamComponent?.instance?.audioPaused === true;
-  const videoPaused = MediaStreamComponent?.instance?.mediaStream === null || MediaStreamComponent?.instance?.videoPaused === true;
+        if (MediaStreamComponent.instance.camAudioProducer == null) await createCamAudioProducer(partyId);
+        else {
+            const audioPaused = MediaStreamComponent.instance.toggleAudioPaused();
+            if (audioPaused === true) await pauseProducer(MediaStreamComponent.instance.camAudioProducer);
+            else await resumeProducer(MediaStreamComponent.instance.camAudioProducer);
+            checkEndVideoChat();
+        }
+    };
 
-  return props.onBoardingStep >= generalStateList.TUTOR_INTERACT ?
+    const handleCamClick = async () => {
+        const partyId = currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId;
+        await checkMediaStream(partyId);
+        if (MediaStreamComponent.instance.camVideoProducer == null) await createCamVideoProducer(partyId);
+        else {
+            const videoPaused = MediaStreamComponent.instance.toggleVideoPaused();
+            if (videoPaused === true) await pauseProducer(MediaStreamComponent.instance.camVideoProducer);
+            else await resumeProducer(MediaStreamComponent.instance.camVideoProducer);
+            checkEndVideoChat();
+        }
+    };
+
+    const audioPaused = MediaStreamComponent?.instance?.mediaStream === null || MediaStreamComponent?.instance?.camAudioProducer == null || MediaStreamComponent?.instance?.audioPaused === true;
+    const videoPaused = MediaStreamComponent?.instance?.mediaStream === null || MediaStreamComponent?.instance?.camVideoProducer == null || MediaStreamComponent?.instance?.videoPaused === true;
+
+    return props.onBoardingStep >= generalStateList.TUTOR_INTERACT ?
         <Card className={styles.drawerBoxContainer}>
-          <CardContent className={styles.drawerBox}>
-            {audioPaused ? <MicOff onClick={handleMicClick} /> : <Mic onClick={handleMicClick} />}
-            {videoPaused ? <VideocamOff onClick={handleCamClick} /> : <Videocam onClick={handleCamClick} />}
-          </CardContent>
+            <CardContent className={styles.drawerBox}>
+                {audioPaused ? <MicOff onClick={handleMicClick} /> : <Mic onClick={handleMicClick} />}
+                {videoPaused ? <VideocamOff onClick={handleCamClick} /> : <Videocam onClick={handleCamClick} />}
+            </CardContent>
         </Card>
-      :null;
+        :null;
 });
 
 export default connect(mapStateToProps)(MediaIconsBox);

--- a/packages/client/components/ui/PartyParticipantWindow/index.tsx
+++ b/packages/client/components/ui/PartyParticipantWindow/index.tsx
@@ -336,7 +336,7 @@ const PartyParticipantWindow = observer((props: Props): JSX.Element => {
                             size="small"
                             className={styles['audio-control']}
                             onClick={(e) => toggleAudio(e)}
-                            style={{visibility : (audioProducerPaused === true || audioProducerGlobalMute === true) ? 'hidden' : 'visible' }}
+                            style={{visibility : (audioStream == null || audioProducerPaused === true || audioProducerGlobalMute === true) ? 'hidden' : 'visible' }}
                         >
                             { ((peerId === 'me_cam' || peerId === 'me_screen') && audioStream && audioProducerPaused === false && audioStreamPaused === false) && <Mic /> }
                             { ((peerId === 'me_cam' || peerId === 'me_screen') && audioStream && audioProducerPaused === false && audioStreamPaused === true) && <MicOff /> }

--- a/packages/client/components/ui/VideoChat/index.tsx
+++ b/packages/client/components/ui/VideoChat/index.tsx
@@ -7,7 +7,7 @@ import { observer } from 'mobx-react';
 import { selectAuthState } from '../../../redux/auth/selector';
 import { selectLocationState } from '../../../redux/location/selector';
 import Fab from "@material-ui/core/Fab";
-import { sendCameraStreams, endVideoChat } from '../../../classes/transports/WebRTCFunctions';
+import { configureMediaTransports, endVideoChat } from '../../../classes/transports/WebRTCFunctions';
 import { useEffect, useState } from 'react';
 
 interface Props {
@@ -35,7 +35,7 @@ const VideoChat = observer((props: Props) => {
   const currentLocation = locationState.get('currentLocation').get('location');
   const gsProvision = async () => {
     if (MediaStreamComponent.instance.mediaStream == null) {
-      await sendCameraStreams(currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId);
+      await configureMediaTransports(currentLocation?.locationSettings?.instanceMediaChatEnabled === true ? 'instance' : user.partyId);
       console.log("Send camera streams called from gsProvision");
     } else {
       await endVideoChat({});

--- a/packages/ops/xr3ngine/Chart.yaml
+++ b/packages/ops/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xr3ngine/templates/game-server-fleet-autoscaler.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-fleet-autoscaler.yaml
@@ -26,7 +26,7 @@ spec:
   policy:
     type: Buffer
     buffer:
-      bufferSize: 1
+      bufferSize: 2
       minReplicas: 2
       maxReplicas: 10
 {{- end }}

--- a/packages/ops/xr3ngine/templates/game-server-fleet.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-fleet.yaml
@@ -461,7 +461,7 @@ spec:
           containerPort: 40099
           protcol: UDP
       health:
-        initialDelaySeconds: 30
+        initialDelaySeconds: 15
         periodSeconds: 30
         # Parameters for game server sidecar
         # sdkServer:


### PR DESCRIPTION
Pared down sendCameraStreams to just attempt to create
party transports if requested and they don't exist.
Renamed it configureMediaTransports.

Moved starting of video and audio producers to separate
functions.

MediaIconsBox now starts each producer separately if it
doesn't exist, otherwise toggles its paused status.

Removed VideoChat button from DrawerControls, but left in
the rest of the associated logic in case we want to draw
from it in the future.

Added function to ServerTransport to send media producers on
transport creation to re-instantiate auto-connection to
existing peers. Thought this was in there somewhere already,
couldn't find it and going back through history wasn't
turning anything up.

Tweaked a couple of gameserver fleet options.