### PR TITLE
Updated auto-connection logic, switched deployment target.

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -19,8 +19,8 @@ jobs:
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET: ${{ secrets.AWS_SECRET }}
-          AWS_REGION: us-east-1
-          CLUSTER_NAME: xr3ngine-demo
+          AWS_REGION: us-west-1
+          CLUSTER_NAME: theoverlay-production
       - name: Publish to DockerHub
         run: bash scripts/publish_dockerhub.sh dev $GITHUB_SHA lagunalabs/xrengine && scripts/deploy.sh dev $GITHUB_SHA
         env:

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -19,8 +19,8 @@ jobs:
         env:
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET: ${{ secrets.AWS_SECRET }}
-          AWS_REGION: us-east-1
-          CLUSTER_NAME: xr3ngine-demo
+          AWS_REGION: us-west-1
+          CLUSTER_NAME: theoverlay-production
       - name: Publish to DockerHub
         run: bash scripts/publish_dockerhub.sh prod $GITHUB_SHA lagunalabs/xrengine && scripts/deploy.sh prod $GITHUB_SHA
         env:

--- a/packages/client/classes/transports/WebRTCFunctions.ts
+++ b/packages/client/classes/transports/WebRTCFunctions.ts
@@ -387,6 +387,9 @@ export async function createTransport(direction: string, partyId?: string) {
             console.log("transport closed ... leaving the and resetting");
             await networkTransport.request(MessageTypes.WebRTCTransportClose.toString(), { transportId: transport.id });
         }
+        if (networkTransport.leaving !== true && state === 'connected' && transport.direction === 'recv') {
+            await networkTransport.request(MessageTypes.WebRTCRequestCurrentProducers.toString(), { partyId: partyId });
+        }
     });
 
     return Promise.resolve(transport);

--- a/packages/client/components/ui/PartyParticipantWindow/index.tsx
+++ b/packages/client/components/ui/PartyParticipantWindow/index.tsx
@@ -273,8 +273,8 @@ const PartyParticipantWindow = observer((props: Props): JSX.Element => {
     const truncateUsername = () => {
         const name = user?.name;
         if (peerId === 'me_cam') return 'You';
-        if (focused === true) return name.length > 20 ? name.slice(0, 20) + '...' : name;
-        if (focused === false) return name.length > 10 ? name.slice(0, 10) + '...' : name;
+        if (focused === true) return name?.length > 20 ? name.slice(0, 20) + '...' : name;
+        if (focused === false) return name?.length > 10 ? name.slice(0, 10) + '...' : name;
     };
 
     return (

--- a/packages/engine/src/networking/enums/MessageTypes.ts
+++ b/packages/engine/src/networking/enums/MessageTypes.ts
@@ -27,6 +27,7 @@ export enum MessageTypes {
   Authorization = 24,
   Kick = 26,
   Ban = 27,
+  WebRTCRequestCurrentProducers = 28,
   Synchronization = 100,
   ClientInput = 101,
   StateUpdate = 102,

--- a/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
+++ b/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
@@ -21,7 +21,23 @@ import {
     handleLeaveWorld,
     validateNetworkObjects
 } from "./NetworkFunctions";
-import { handleWebRtcCloseConsumer, handleWebRtcCloseProducer, handleWebRtcConsumerSetLayers, handleWebRtcPauseConsumer, handleWebRtcPauseProducer, handleWebRtcProduceData, handleWebRtcReceiveTrack, handleWebRtcResumeConsumer, handleWebRtcResumeProducer, handleWebRtcSendTrack, handleWebRtcTransportClose, handleWebRtcTransportConnect, handleWebRtcTransportCreate, startWebRTC } from './WebRTCFunctions';
+import {
+    handleWebRtcCloseConsumer,
+    handleWebRtcCloseProducer,
+    handleWebRtcConsumerSetLayers,
+    handleWebRtcPauseConsumer,
+    handleWebRtcPauseProducer,
+    handleWebRtcProduceData,
+    handleWebRtcReceiveTrack,
+    handleWebRtcResumeConsumer,
+    handleWebRtcResumeProducer,
+    handleWebRtcSendTrack,
+    handleWebRtcTransportClose,
+    handleWebRtcTransportConnect,
+    handleWebRtcTransportCreate,
+    handleWebRtcRequestCurrentProducers,
+    startWebRTC
+} from './WebRTCFunctions';
 
 const gsNameRegex = /gameserver-([a-zA-Z0-9]{5}-[a-zA-Z0-9]{5})/;
 const Route53 = new AWS.Route53({ ...config.aws.route53.keys });
@@ -190,6 +206,9 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
 
                 socket.on(MessageTypes.WebRTCPauseProducer.toString(), async (data, callback) =>
                     handleWebRtcPauseProducer(socket, data, callback));
+
+                socket.on(MessageTypes.WebRTCRequestCurrentProducers.toString(), async(data, callback) =>
+                    handleWebRtcRequestCurrentProducers(socket, data, callback));
             });
         });
     }

--- a/packages/server/src/gameserver/transports/WebRTCFunctions.ts
+++ b/packages/server/src/gameserver/transports/WebRTCFunctions.ts
@@ -68,8 +68,6 @@ export const sendInitialProducers = async (socket: SocketIO.Socket, partyId?: st
             logger.info(`Sending media for ${name}`);
             Object.entries(value.media).map(([subName, subValue]) => {
                 if (partyId === (subValue as any).partyId) {
-                    console.log('Sending media for ' + subName);
-                    console.log((subValue as any).producerId);
                     selfClient.socket.emit(MessageTypes.WebRTCCreateProducer.toString(), value.userId, subName, (subValue as any).producerId, partyId);
                 }
             });
@@ -242,7 +240,6 @@ export async function handleWebRtcTransportCreate(socket, data: CreateWebRtcTran
         dtlsParameters
     };
 
-    sendInitialProducers(socket, partyId);
     // Create data consumers for other clients if the current client transport receives data producer on it
     newTransport.observer.on('newdataproducer', handleConsumeDataEvent(socket));
     newTransport.observer.on('newproducer', sendCurrentProducers(socket, partyId));
@@ -482,4 +479,11 @@ export async function handleWebRtcPauseProducer(socket, data, callback): Promise
         hostClient[1].socket.emit(MessageTypes.WebRTCPauseProducer.toString(), producer.id, true);
     }
     callback({ paused: true });
+}
+
+export async function handleWebRtcRequestCurrentProducers(socket, data, callback): Promise<any> {
+    const { partyId } = data;
+
+    await sendInitialProducers(socket, partyId);
+    callback({requested: true});
 }


### PR DESCRIPTION
Problems with auto-connection may have stemmed from clients trying to
connect before their receive transport was ready. Sending of initial
producers is not part of the transport create handler anymore, but is
triggered by reception of new message 'WebRTCRequestCurrentProducers'.
On the client, this is sent when the receive transport changes to state
'connected'.

Added some conditional checks to PartyParticipantWindow on truncateUsername.
There are some times in local where the user might be undefined, and this was
causing uncaught errors.

Switched Github Actions to point to new TheOverlay deployment.