### PR TITLE
Modifications to CI/CD process.

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -21,6 +21,10 @@ jobs:
           AWS_SECRET: ${{ secrets.AWS_SECRET }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           CLUSTER_NAME: theoverlay-production
+      - name: Build Docker Image
+        run: bash scripts/build_docker.sh $DOCKER_LABEL
+        env:
+          DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
       - name: Publish to DockerHub
         run: bash scripts/publish_dockerhub.sh $GITHUB_SHA $DOCKER_LABEL
         env:
@@ -28,7 +32,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
       - name: Publish to Elastic Container Registry
-        run: bash scripts/publish_ecr.sh $GITHUB_SHA $DOCKER_LABEL
+        run: bash scripts/publish_ecr.sh dev $GITHUB_SHA $DOCKER_LABEL
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.REPO_NAME }}

--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -21,6 +21,10 @@ jobs:
           AWS_SECRET: ${{ secrets.AWS_SECRET }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           CLUSTER_NAME: theoverlay-production
+      - name: Build Docker Image
+        run: bash scripts/build_docker.sh $DOCKER_LABEL
+        env:
+          DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
       - name: Publish to DockerHub
         run: bash scripts/publish_dockerhub.sh $GITHUB_SHA $DOCKER_LABEL
         env:
@@ -28,7 +32,7 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
       - name: Publish to Elastic Container Registry
-        run: bash scripts/publish_ecr.sh $GITHUB_SHA $DOCKER_LABEL
+        run: bash scripts/publish_ecr.sh prod $GITHUB_SHA $DOCKER_LABEL
         env:
           DOCKER_LABEL: ${{ secrets.DOCKER_LABEL }}
           REPO_NAME: ${{ secrets.REPO_NAME }}

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "ts-jest": "^26.4.1"
   },
   "dependencies": {
+    "aws-sdk": "^2.811.0",
     "text-encoding": "^0.7.0",
     "ts-jest": "^26.4.1"
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -98,7 +98,7 @@
     "@feathersjs/transport-commons": "^4.5.9",
     "@google-cloud/agones-sdk": "^1.7.0",
     "@xr3ngine/common": "^0.2.0",
-    "aws-sdk": "^2.658.0",
+    "aws-sdk": "^2.811.0",
     "bent": "^7.3.0",
     "cannon-es-debugger": "^0.0.4",
     "chargebee": "^2.5.7",

--- a/scripts/build_docker.sh
+++ b/scripts/build_docker.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+set -x
+
+LABEL=$1
+
+docker build --tag $LABEL .

--- a/scripts/prune_ecr_images.js
+++ b/scripts/prune_ecr_images.js
@@ -1,0 +1,30 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+const cli = require('cli');
+const AWS = require('aws-sdk');
+
+cli.enable('status');
+
+const options = cli.parse({
+    repoName: [false, 'Name of repository', 'string']
+});
+
+cli.main(async () => {
+    try {
+        const ecrPublic = new AWS.ECRPUBLIC({region: 'us-east-1'});
+        const result = await ecrPublic.describeImages({repositoryName: options.repoName || 'xrengine'}).promise();
+        const images = result.imageDetails;
+        const withoutLatest = images.filter(image => image.imageTags.indexOf('latest_dev') < 0 && image.imageTags.indexOf('latest_prod') < 0);
+        const sorted = withoutLatest.sort((a, b) => b.imagePushedAt - a.imagePushedAt);
+        const toBeDeleted = sorted.slice(10,);
+        if (toBeDeleted.length > 0) {
+            const deleteParams = {
+                imageIds: toBeDeleted.map(image => { return { imageDigest: image.imageDigest } }),
+                repositoryName: options.repoName || 'xrengine'
+            };
+            await ecrPublic.batchDeleteImage(deleteParams).promise();
+        }
+    } catch(err) {
+        console.log('Error in deleting old ECR images:');
+        console.log(err);
+    }
+});

--- a/scripts/publish_dockerhub.sh
+++ b/scripts/publish_dockerhub.sh
@@ -5,7 +5,6 @@ set -x
 TAG=$1
 LABEL=$2
 
-docker build --tag ${LABEL} .
 echo "$DOCKER_HUB_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 docker tag ${LABEL} ${LABEL}:${TAG}

--- a/scripts/publish_ecr.sh
+++ b/scripts/publish_ecr.sh
@@ -2,14 +2,14 @@
 set -e
 set -x
 
-TAG=$1
-LABEL=$2
+STAGE=$1
+TAG=$2
+LABEL=$3
 
-#If publish_dockerhub.sh is removed, or this script is made to run before it,
-#uncomment the docker build line; the current setup assumes that the Docker
-#image has already been built
-#docker build --tag ${LABEL} .
 aws ecr-public get-login-password --region us-east-1 | docker login -u AWS --password-stdin $ECR_URL
+node ./prune_ecr_images.js --repoName $REPO_NAME
 
 docker tag $LABEL $ECR_URL/$REPO_NAME:$TAG
+docker tag $LABEL $ECR_URL/$REPO_NAME:latest_$STAGE
 docker push $ECR_URL/$REPO_NAME:$TAG
+docker push $ECR_URL/$REPO_NAME:latest_$STAGE


### PR DESCRIPTION
Split Docker build into separate script.
publish_ecr tags images as latest_<stage>. Before pushing,
prunes ECR repo down to latest dev and prod builds, plus the
10 most recent builds other than those, so that we don't incur unnecessary
storage costs on ECR (Docker Hub is free).