### PR TITLE
Hackfix to model upload flow.

### DIFF
--- a/packages/client/components/editor/Api.tsx
+++ b/packages/client/components/editor/Api.tsx
@@ -978,7 +978,8 @@ export default class Api extends EventEmitter {
 
     const {
       file_id: assetFileId,
-      meta: { access_token: assetAccessToken }
+      meta: { access_token: assetAccessToken, expected_content_type: expectedContentType },
+      origin: origin
     } = await this.upload(file, onProgress, signal) as any;
 
     const delta = Date.now() - this.lastUploadAssetRequest;
@@ -1004,23 +1005,23 @@ export default class Api extends EventEmitter {
       }
     });
 
-    const resp = await this.fetchUrl(endpoint, { method: "POST", headers, body, signal });
-    console.log("Response: " + Object.values(resp));
-
-    const json = await resp.json();
-
-    const asset = json.assets[0];
-
+    // const resp = await this.fetchUrl(endpoint, { method: "POST", headers, body, signal });
+    // console.log("Response: " + Object.values(resp));
+    //
+    // const json = await resp.json();
+    //
+    // const asset = json.assets[0];
+    //
     this.lastUploadAssetRequest = Date.now();
 
     return {
-      id: asset.asset_id,
-      name: asset.name,
-      url: asset.file_url,
-      type: asset.type,
+      id: assetFileId,
+      name: file.name,
+      url: origin,
+      type: 'application/octet-stream',
       attributions: {},
       images: {
-        preview: { url: asset.thumbnail_url }
+        preview: { url: file.thumbnail_url }
       }
     };
   }


### PR DESCRIPTION
There was a seemingly-unnecessary POST to /static-resource in _uploadAsset in Editor/Api.tsx
that was erroring out due to not sending the correct fields for a static-resource.
It appears that the static-resource is already created in a prior POST to /media.
The call to /static-resource has been commented out and the return object from _uploadAsset
has been slightly modified to use what's returned from .upload.

This should be looked at further, though, since I'm guessing what was commented out is
supposed to do something useful.