### PR TITLE
Removed origins from socketio configuration.

### DIFF
--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -87,7 +87,6 @@ if (config.server.enabled) {
     app.configure(express.rest());
     app.configure(socketio({
       serveClient: false,
-      origins: [config.client.url],
       handlePreflightRequest: (req, res) => {
         // Set CORS headers
         if (res != null) {


### PR DESCRIPTION
Socketio pushed out new version that undid disabling of CORS by default.
For some reason, 'origins' option is not working in new version, so it has
been removed, and things work again.