### PR TITLE
-remove -55px left margin for chat container on mobile; - remove blue…

### DIFF
--- a/packages/client/components/ui/InstanceChat/InstanceChat.module.scss
+++ b/packages/client/components/ui/InstanceChat/InstanceChat.module.scss
@@ -126,6 +126,9 @@
     height: 30vh;   
     background-color: transparent;
     margin-left: -55px;
+    @media (max-width: 768px) {
+      margin-left: 0;
+    }
     
   .message-container {
     display: flex;

--- a/packages/client/components/ui/UserMenu/UserMenu.module.scss
+++ b/packages/client/components/ui/UserMenu/UserMenu.module.scss
@@ -10,6 +10,10 @@
     background-image: url('../assets/ll_hamburger.png');
     background-position: 30% center;
     background-repeat: no-repeat; 
+    -webkit-tap-highlight-color: transparent;
+    :active{
+        -webkit-tap-highlight-color: transparent;
+    }
 }
 .drawer{
     display: flex; 


### PR DESCRIPTION
… default bg for active pressed element (usermenu hamburger icon)