### PR TITLE
Updated sequelize config to use utf8mb4.

### DIFF
--- a/packages/client/components/editor/configs.ts
+++ b/packages/client/components/editor/configs.ts
@@ -23,6 +23,6 @@ get(configs, "SENTRY_DSN", process.env.SENTRY_DSN);
 (configs as any).longName = (): string => "Scene Editor";
 (configs as any).SERVER_URL = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.apiServer : 'https://localhost:3030';
 (configs as any).APP_URL = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.appServer : 'https://localhost:3000';
-(configs as any).FEATHER_STORE_KEY = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.featherStoreKey : 'TheOverlay-Auth-Store';
+(configs as any).FEATHERS_STORE_KEY = process.env.NODE_ENV === 'production' ? publicRuntimeConfig.feathersStoreKey : 'TheOverlay-Auth-Store';
 
 export default configs;

--- a/packages/server/src/config.ts
+++ b/packages/server/src/config.ts
@@ -23,7 +23,9 @@ export const db: any = {
   port: process.env.MYSQL_PORT ?? 3306,
   dialect: 'mysql',
   forceRefresh: process.env.FORCE_DB_REFRESH === 'true',
-  url: ''
+  url: '',
+  charset: 'utf8mb4',
+  collate: 'utf8mb4_general_ci'
 };
 db.url = process.env.MYSQL_URL ??
   `mysql://${db.username}:${db.password}@${db.host}:${db.port}/${db.database}`;


### PR DESCRIPTION
For whatever reason, default UTF-8 charset only includes
3-byte characters. Updated it to use utf8mb4, which includes
4-byte characters.

Updated editor API from using separate entry in localStorage
for a copy of access token (and email, which was a dummy that
I don't think was in use anywhere anyway) to using main
entry pointed to by FEATHERS_STORE_KEY (updated this name, too).
Separate entry was causing a bug after DB wipes, as it was holding
old access tokens that were being used on initial project fetches.