### PR TITLE
Fixed a bug with Network cleanup on timeout.

### DIFF
--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -26,6 +26,7 @@
     "webpack": "^5.1.0"
   },
   "dependencies": {
+    "@google-cloud/agones-sdk": "^1.11.0",
     "puppeteer": "^5.5.0",
     "three": "^0.124.0"
   },

--- a/packages/bot/run-bot.js
+++ b/packages/bot/run-bot.js
@@ -1,4 +1,7 @@
 const xr3ngineBot = require('./src/xr3ngine-bot');
+const AgonesSDK = require('@google-cloud/agones-sdk');
+
+const agonesSDK = new AgonesSDK();
 
 async function runDirection(bot, key, numSeconds) {
     console.log('Running with key ' + key);
@@ -26,15 +29,30 @@ async function sendChatMessages(bot) {
 }
 
 async function runBot() {
-    const bot = new xr3ngineBot();
-    const domain = process.env.DOMAIN || 'localhost:3000';
-    const locationName = process.env.LOCATION_NAME || 'test';
-    await bot.enterRoom(`https://${domain}/location/${locationName}`, { name: 'bot1'});
-    await runInCircle(bot, 2000);
-    await sendChatMessages(bot);
-    setTimeout(() => {
-        process.exit(0);
-    }, 3000)
+    try {
+        if (process.env.KUBERNETES === 'true') {
+            agonesSDK.connect();
+            agonesSDK.ready();
+            setInterval(() => {
+                agonesSDK.health();
+            }, 1000)
+        }
+        const bot = new xr3ngineBot();
+        const domain = process.env.DOMAIN || 'localhost:3000';
+        const locationName = process.env.LOCATION_NAME || 'test';
+        await bot.enterRoom(`https://${domain}/location/${locationName}`, {name: 'bot1'});
+        await runInCircle(bot, 2000);
+        await sendChatMessages(bot);
+        setTimeout(async () => {
+            await bot.browser.close()
+            process.exit(0);
+        }, 3000)
+    } catch(err) {
+        console.log('Bot error');
+        console.log(err);
+        if (bot && bot.browser) bot.browser.close();
+        process.exit(1);
+    }
 }
 
 runBot();

--- a/packages/bot/src/xr3ngine-bot.js
+++ b/packages/bot/src/xr3ngine-bot.js
@@ -121,7 +121,7 @@ class XR3ngineBot {
         console.log('Launching browser')
         this.browser = await BrowserLauncher.browser({headless: this.headless, args: [
             '--ignore-certificate-errors'
-            ]});
+        ]});
         console.log(this.browser)
         this.page = await this.browser.newPage();
 
@@ -131,6 +131,7 @@ class XR3ngineBot {
         }
 
         this.page.setViewport({ width: 1600, height: 900});
+        await this.page.setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36')
 
         const context = this.browser.defaultBrowserContext();
         context.overridePermissions("https://theoverlay.io", ['microphone', 'camera'])
@@ -167,8 +168,8 @@ class XR3ngineBot {
         }
 
         console.log('Going to ' + roomUrl);
-        await this.page.goto(roomUrl, {waitUntil: 'domcontentloaded'})
-        await this.page.waitFor("button", { timeout: 60000})
+        this.page.goto(roomUrl, {waitUntil: 'domcontentloaded'})
+        await this.page.waitForSelector("button.join_world", { timeout: 60000})
 
         if (this.headless) {
             // Disable rendering for headless, otherwise chromium uses a LOT of CPU
@@ -181,9 +182,10 @@ class XR3ngineBot {
         await new Promise(resolve => {setTimeout(async() => {
             await this.pu.clickSelectorClassRegex("button", /join_world/);
             setTimeout(async() => {
+                // await this.page.waitForSelector('button.openChat');
                 await this.page.mouse.click(0, 0);
                 resolve();
-            }, 10000)
+            }, 100000)
         }, 2000) });
     }
 

--- a/packages/ops/xr3ngine-bot/templates/bot-cluster-role.yaml
+++ b/packages/ops/xr3ngine-bot/templates/bot-cluster-role.yaml
@@ -21,4 +21,19 @@ rules:
       - create
       - update
       - delete
+  - apiGroups:
+      - "agones.dev"
+    resources:
+      - fleets
+      - fleet
+      - fleets.agones.dev
+      - configmap
+      - gameservers
+      - gameserver
+      - gameserversets
+    verbs:
+      - get
+      - update
+      - list
+      - watch
 {{- end }}

--- a/packages/server/src/gameserver/transports/NetworkFunctions.ts
+++ b/packages/server/src/gameserver/transports/NetworkFunctions.ts
@@ -139,11 +139,12 @@ export function validateNetworkObjects(): void {
             networkObjectsClientOwns.forEach(obj => {
                 // Get the entity attached to the NetworkObjectComponent and remove it
                 logger.info("Removed entity ", (obj.component.entity as Entity).id, " for user ", userId);
-                const removeMessage = { networkId: obj.networkId };
+                const removeMessage = { networkId: obj.component.networkId };
                 Network.instance.destroyObjects.push(removeMessage);
                 // if (Network.instance.worldState.inputs[obj.networkId])
-                delete Network.instance.worldState.inputs[obj.networkId];
                 removeEntity(obj.component.entity);
+                delete Network.instance.networkObjects[obj.id];
+                delete Network.instance.worldState.inputs[obj.networkId];
             });
 
             if (Network.instance.clients[userId])


### PR DESCRIPTION
Network cleanup when a client timed out wasn't removing networked objects properly.

Fixed some issues with Bot deployment. puppeteer seems to run very slowly in K8s,
so some of the waits have been significantly extended so that certain events,
like JoinWorld, have enough time to go through. Need to investigate further
whether puppeteer can be sped up.