### PR TITLE
Fixed a bug with calls for WebRTCReceiveTrack().

### DIFF
--- a/packages/client/classes/transports/WebRTCFunctions.ts
+++ b/packages/client/classes/transports/WebRTCFunctions.ts
@@ -195,7 +195,7 @@ export async function subscribeToTrack(peerId: string, mediaTag: string, partyId
     );
 
     // Only continue if we have a valid id
-    if (consumerParameters.id == null) return;
+    if (consumerParameters?.id == null) return;
 
     consumer = partyId === 'instance' ?
         await networkTransport.instanceRecvTransport.consume({ ...consumerParameters, appData: { peerId, mediaTag }, paused: true })


### PR DESCRIPTION
On prod, the gameserver was sometimes crashing because handleWebRtcReceiveTrack()
in the gameserver transport was getting 'null' when finding a transport, and
transport.consume() was not conditional on transport being not-null.

Added a conditional check, and if it's null, just return an object with id: null,
so that the client will ignore that consume attempt.

Not sure why this is occurring, as that suggests the client's transport is crashing
or something, but at least this should prevent the whole GS from going down.