### PR TITLE
Agones and Helm chart updates

### DIFF
--- a/packages/ops/configs/agones-default-values.yaml
+++ b/packages/ops/configs/agones-default-values.yaml
@@ -15,7 +15,7 @@
 # Declare variables to be passed into your templates.
 
 agones:
-  featureGates: ""
+  featureGates: "RollingUpdateOnReady=true"
   metrics:
     prometheusEnabled: true
     prometheusServiceDiscovery: true
@@ -125,7 +125,7 @@ agones:
     generateTLS: true
   image:
     registry: gcr.io/agones-images
-    tag: 1.5.0
+    tag: 1.11.0
     controller:
       name: agones-controller
       pullPolicy: IfNotPresent

--- a/packages/ops/xr3ngine/Chart.yaml
+++ b/packages/ops/xr3ngine/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.2.3
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/packages/ops/xr3ngine/templates/game-server-fleet.yaml
+++ b/packages/ops/xr3ngine/templates/game-server-fleet.yaml
@@ -52,7 +52,7 @@ spec:
     # GameServer metadata
     metadata:
       labels:
-        {{- include "xr3ngine.gameserver.labels" . | nindent 4 }}
+        {{- include "xr3ngine.gameserver.labels" . | nindent 8 }}
     # GameServer specification
     spec:
       ports:
@@ -63,403 +63,403 @@ spec:
         - name: udp-40000
           portPolicy: Dynamic
           containerPort: 40000
-          protcol: UDP
+          protocol: UDP
         - name: udp-40001
           portPolicy: Dynamic
           containerPort: 40001
-          protcol: UDP
+          protocol: UDP
         - name: udp-40002
           portPolicy: Dynamic
           containerPort: 40002
-          protcol: UDP
+          protocol: UDP
         - name: udp-40003
           portPolicy: Dynamic
           containerPort: 40003
-          protcol: UDP
+          protocol: UDP
         - name: udp-40004
           portPolicy: Dynamic
           containerPort: 40004
-          protcol: UDP
+          protocol: UDP
         - name: udp-40005
           portPolicy: Dynamic
           containerPort: 40005
-          protcol: UDP
+          protocol: UDP
         - name: udp-40006
           portPolicy: Dynamic
           containerPort: 40006
-          protcol: UDP
+          protocol: UDP
         - name: udp-40007
           portPolicy: Dynamic
           containerPort: 40007
-          protcol: UDP
+          protocol: UDP
         - name: udp-40008
           portPolicy: Dynamic
           containerPort: 40008
-          protcol: UDP
+          protocol: UDP
         - name: udp-40009
           portPolicy: Dynamic
           containerPort: 40009
-          protcol: UDP
+          protocol: UDP
         - name: udp-40010
           portPolicy: Dynamic
           containerPort: 40010
-          protcol: UDP
+          protocol: UDP
         - name: udp-40011
           portPolicy: Dynamic
           containerPort: 40011
-          protcol: UDP
+          protocol: UDP
         - name: udp-40012
           portPolicy: Dynamic
           containerPort: 40012
-          protcol: UDP
+          protocol: UDP
         - name: udp-40013
           portPolicy: Dynamic
           containerPort: 40013
-          protcol: UDP
+          protocol: UDP
         - name: udp-40014
           portPolicy: Dynamic
           containerPort: 40014
-          protcol: UDP
+          protocol: UDP
         - name: udp-40015
           portPolicy: Dynamic
           containerPort: 40015
-          protcol: UDP
+          protocol: UDP
         - name: udp-40016
           portPolicy: Dynamic
           containerPort: 40016
-          protcol: UDP
+          protocol: UDP
         - name: udp-40017
           portPolicy: Dynamic
           containerPort: 40017
-          protcol: UDP
+          protocol: UDP
         - name: udp-40018
           portPolicy: Dynamic
           containerPort: 40018
-          protcol: UDP
+          protocol: UDP
         - name: udp-40019
           portPolicy: Dynamic
           containerPort: 40019
-          protcol: UDP
+          protocol: UDP
         - name: udp-40020
           portPolicy: Dynamic
           containerPort: 40020
-          protcol: UDP
+          protocol: UDP
         - name: udp-40021
           portPolicy: Dynamic
           containerPort: 40021
-          protcol: UDP
+          protocol: UDP
         - name: udp-40022
           portPolicy: Dynamic
           containerPort: 40022
-          protcol: UDP
+          protocol: UDP
         - name: udp-40023
           portPolicy: Dynamic
           containerPort: 40023
-          protcol: UDP
+          protocol: UDP
         - name: udp-40024
           portPolicy: Dynamic
           containerPort: 40024
-          protcol: UDP
+          protocol: UDP
         - name: udp-40025
           portPolicy: Dynamic
           containerPort: 40025
-          protcol: UDP
+          protocol: UDP
         - name: udp-40026
           portPolicy: Dynamic
           containerPort: 40026
-          protcol: UDP
+          protocol: UDP
         - name: udp-40027
           portPolicy: Dynamic
           containerPort: 40027
-          protcol: UDP
+          protocol: UDP
         - name: udp-40028
           portPolicy: Dynamic
           containerPort: 40028
-          protcol: UDP
+          protocol: UDP
         - name: udp-40029
           portPolicy: Dynamic
           containerPort: 40029
-          protcol: UDP
+          protocol: UDP
         - name: udp-40030
           portPolicy: Dynamic
           containerPort: 40030
-          protcol: UDP
+          protocol: UDP
         - name: udp-40031
           portPolicy: Dynamic
           containerPort: 40031
-          protcol: UDP
+          protocol: UDP
         - name: udp-40032
           portPolicy: Dynamic
           containerPort: 40032
-          protcol: UDP
+          protocol: UDP
         - name: udp-40033
           portPolicy: Dynamic
           containerPort: 40033
-          protcol: UDP
+          protocol: UDP
         - name: udp-40034
           portPolicy: Dynamic
           containerPort: 40034
-          protcol: UDP
+          protocol: UDP
         - name: udp-40035
           portPolicy: Dynamic
           containerPort: 40035
-          protcol: UDP
+          protocol: UDP
         - name: udp-40036
           portPolicy: Dynamic
           containerPort: 40036
-          protcol: UDP
+          protocol: UDP
         - name: udp-40037
           portPolicy: Dynamic
           containerPort: 40037
-          protcol: UDP
+          protocol: UDP
         - name: udp-40038
           portPolicy: Dynamic
           containerPort: 40038
-          protcol: UDP
+          protocol: UDP
         - name: udp-40039
           portPolicy: Dynamic
           containerPort: 40039
-          protcol: UDP
+          protocol: UDP
         - name: udp-40040
           portPolicy: Dynamic
           containerPort: 40040
-          protcol: UDP
+          protocol: UDP
         - name: udp-40041
           portPolicy: Dynamic
           containerPort: 40041
-          protcol: UDP
+          protocol: UDP
         - name: udp-40042
           portPolicy: Dynamic
           containerPort: 40042
-          protcol: UDP
+          protocol: UDP
         - name: udp-40043
           portPolicy: Dynamic
           containerPort: 40043
-          protcol: UDP
+          protocol: UDP
         - name: udp-40044
           portPolicy: Dynamic
           containerPort: 40044
-          protcol: UDP
+          protocol: UDP
         - name: udp-40045
           portPolicy: Dynamic
           containerPort: 40045
-          protcol: UDP
+          protocol: UDP
         - name: udp-40046
           portPolicy: Dynamic
           containerPort: 40046
-          protcol: UDP
+          protocol: UDP
         - name: udp-40047
           portPolicy: Dynamic
           containerPort: 40047
-          protcol: UDP
+          protocol: UDP
         - name: udp-40048
           portPolicy: Dynamic
           containerPort: 40048
-          protcol: UDP
+          protocol: UDP
         - name: udp-40049
           portPolicy: Dynamic
           containerPort: 40049
-          protcol: UDP
+          protocol: UDP
         - name: udp-40050
           portPolicy: Dynamic
           containerPort: 40050
-          protcol: UDP
+          protocol: UDP
         - name: udp-40051
           portPolicy: Dynamic
           containerPort: 40051
-          protcol: UDP
+          protocol: UDP
         - name: udp-40052
           portPolicy: Dynamic
           containerPort: 40052
-          protcol: UDP
+          protocol: UDP
         - name: udp-40053
           portPolicy: Dynamic
           containerPort: 40053
-          protcol: UDP
+          protocol: UDP
         - name: udp-40054
           portPolicy: Dynamic
           containerPort: 40054
-          protcol: UDP
+          protocol: UDP
         - name: udp-40055
           portPolicy: Dynamic
           containerPort: 40055
-          protcol: UDP
+          protocol: UDP
         - name: udp-40056
           portPolicy: Dynamic
           containerPort: 40056
-          protcol: UDP
+          protocol: UDP
         - name: udp-40057
           portPolicy: Dynamic
           containerPort: 40057
-          protcol: UDP
+          protocol: UDP
         - name: udp-40058
           portPolicy: Dynamic
           containerPort: 40058
-          protcol: UDP
+          protocol: UDP
         - name: udp-40059
           portPolicy: Dynamic
           containerPort: 40059
-          protcol: UDP
+          protocol: UDP
         - name: udp-40060
           portPolicy: Dynamic
           containerPort: 40060
-          protcol: UDP
+          protocol: UDP
         - name: udp-40061
           portPolicy: Dynamic
           containerPort: 40061
-          protcol: UDP
+          protocol: UDP
         - name: udp-40062
           portPolicy: Dynamic
           containerPort: 40062
-          protcol: UDP
+          protocol: UDP
         - name: udp-40063
           portPolicy: Dynamic
           containerPort: 40063
-          protcol: UDP
+          protocol: UDP
         - name: udp-40064
           portPolicy: Dynamic
           containerPort: 40064
-          protcol: UDP
+          protocol: UDP
         - name: udp-40065
           portPolicy: Dynamic
           containerPort: 40065
-          protcol: UDP
+          protocol: UDP
         - name: udp-40066
           portPolicy: Dynamic
           containerPort: 40066
-          protcol: UDP
+          protocol: UDP
         - name: udp-40067
           portPolicy: Dynamic
           containerPort: 40067
-          protcol: UDP
+          protocol: UDP
         - name: udp-40068
           portPolicy: Dynamic
           containerPort: 40068
-          protcol: UDP
+          protocol: UDP
         - name: udp-40069
           portPolicy: Dynamic
           containerPort: 40069
-          protcol: UDP
+          protocol: UDP
         - name: udp-40070
           portPolicy: Dynamic
           containerPort: 40070
-          protcol: UDP
+          protocol: UDP
         - name: udp-40071
           portPolicy: Dynamic
           containerPort: 40071
-          protcol: UDP
+          protocol: UDP
         - name: udp-40072
           portPolicy: Dynamic
           containerPort: 40072
-          protcol: UDP
+          protocol: UDP
         - name: udp-40073
           portPolicy: Dynamic
           containerPort: 40073
-          protcol: UDP
+          protocol: UDP
         - name: udp-40074
           portPolicy: Dynamic
           containerPort: 40074
-          protcol: UDP
+          protocol: UDP
         - name: udp-40075
           portPolicy: Dynamic
           containerPort: 40075
-          protcol: UDP
+          protocol: UDP
         - name: udp-40076
           portPolicy: Dynamic
           containerPort: 40076
-          protcol: UDP
+          protocol: UDP
         - name: udp-40077
           portPolicy: Dynamic
           containerPort: 40077
-          protcol: UDP
+          protocol: UDP
         - name: udp-40078
           portPolicy: Dynamic
           containerPort: 40078
-          protcol: UDP
+          protocol: UDP
         - name: udp-40079
           portPolicy: Dynamic
           containerPort: 40079
-          protcol: UDP
+          protocol: UDP
         - name: udp-40080
           portPolicy: Dynamic
           containerPort: 40080
-          protcol: UDP
+          protocol: UDP
         - name: udp-40081
           portPolicy: Dynamic
           containerPort: 40081
-          protcol: UDP
+          protocol: UDP
         - name: udp-40082
           portPolicy: Dynamic
           containerPort: 40082
-          protcol: UDP
+          protocol: UDP
         - name: udp-40083
           portPolicy: Dynamic
           containerPort: 40083
-          protcol: UDP
+          protocol: UDP
         - name: udp-40084
           portPolicy: Dynamic
           containerPort: 40084
-          protcol: UDP
+          protocol: UDP
         - name: udp-40085
           portPolicy: Dynamic
           containerPort: 40085
-          protcol: UDP
+          protocol: UDP
         - name: udp-40086
           portPolicy: Dynamic
           containerPort: 40086
-          protcol: UDP
+          protocol: UDP
         - name: udp-40087
           portPolicy: Dynamic
           containerPort: 40087
-          protcol: UDP
+          protocol: UDP
         - name: udp-40088
           portPolicy: Dynamic
           containerPort: 40088
-          protcol: UDP
+          protocol: UDP
         - name: udp-40089
           portPolicy: Dynamic
           containerPort: 40089
-          protcol: UDP
+          protocol: UDP
         - name: udp-40090
           portPolicy: Dynamic
           containerPort: 40090
-          protcol: UDP
+          protocol: UDP
         - name: udp-40091
           portPolicy: Dynamic
           containerPort: 40091
-          protcol: UDP
+          protocol: UDP
         - name: udp-40092
           portPolicy: Dynamic
           containerPort: 40092
-          protcol: UDP
+          protocol: UDP
         - name: udp-40093
           portPolicy: Dynamic
           containerPort: 40093
-          protcol: UDP
+          protocol: UDP
         - name: udp-40094
           portPolicy: Dynamic
           containerPort: 40094
-          protcol: UDP
+          protocol: UDP
         - name: udp-40095
           portPolicy: Dynamic
           containerPort: 40095
-          protcol: UDP
+          protocol: UDP
         - name: udp-40096
           portPolicy: Dynamic
           containerPort: 40096
-          protcol: UDP
+          protocol: UDP
         - name: udp-40097
           portPolicy: Dynamic
           containerPort: 40097
-          protcol: UDP
+          protocol: UDP
         - name: udp-40098
           portPolicy: Dynamic
           containerPort: 40098
-          protcol: UDP
+          protocol: UDP
         - name: udp-40099
           portPolicy: Dynamic
           containerPort: 40099
-          protcol: UDP
+          protocol: UDP
       health:
         initialDelaySeconds: 15
         periodSeconds: 30

--- a/packages/ops/xr3ngine/values.yaml
+++ b/packages/ops/xr3ngine/values.yaml
@@ -341,4 +341,4 @@ agones:
   enabled: false
 
 redis:
-  enabled: true
+  enabled: false

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -36,16 +36,6 @@ const emitter = new EventEmitter();
 const app = express(feathers()) as Application;
 const agonesSDK = new AgonesSDK();
 
-function healthPing(agonesSDK: AgonesSDK): void {
-  try {
-    agonesSDK.health();
-    setTimeout(() => healthPing(agonesSDK), 100000);
-  } catch(err) {
-    console.log('Agones healthping error');
-    console.log(err);
-  }
-}
-
 app.set('nextReadyEmitter', emitter);
 
 console.log("***************** OPEN API PATH IS");
@@ -166,7 +156,7 @@ if (config.server.enabled) {
       });    
 
       (app as any).agonesSDK = agonesSDK;
-      healthPing(agonesSDK);
+      setInterval(() => agonesSDK.health(), 1000);
 
       // Create new gameserver instance
       const gameServer = new WebRTCGameServer(app);


### PR DESCRIPTION
Updated agones to v1.11.
Enabled 'RollingUpdateOnReady' feature.

Fixed some bugs in game-server-fleet.yaml.

Rolled back inadvertent change in Agones health check interval
and made it a setInterval() instead of a function that calls
setTimeout.

Made redis.enabled false by default. Reinstalling it on every
helm upgrade of XR3ngine was behind every gameserver immediately
going down - they all errored out due to losing their redis connection.
Redis should be installed separately from XR3ngine.