### PR TITLE
Implemented working unreliable messaging.

### DIFF
--- a/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
+++ b/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
@@ -3,7 +3,7 @@ import { NetworkTransport } from "@xr3ngine/engine/src/networking/interfaces/Net
 import { CreateWebRtcTransportParams } from "@xr3ngine/engine/src/networking/types/NetworkingTypes";
 import AWS from 'aws-sdk';
 import * as https from "https";
-import { DataProducer, Router, Transport, Worker } from "mediasoup/lib/types";
+import {DataProducer, DataConsumer, Router, Transport, Worker, DataProducerOptions} from "mediasoup/lib/types";
 import SocketIO, { Socket } from "socket.io";
 import logger from '../../app/logger';
 import config from '../../config';
@@ -53,6 +53,8 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
     transport: Transport
     app: any
     dataProducers: DataProducer[] = []
+    outgoingDataTransport: Transport
+    outgoingDataProducer: DataProducer
     gameServer;
 
     constructor(app) {
@@ -63,8 +65,10 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
         if (this.socketIO != null) this.socketIO.of('/realtime').emit(MessageTypes.ReliableMessage.toString(), message);
     }
 
-    public sendData = (data: any): void =>
-      this.dataProducers?.forEach(producer => { producer.send(JSON.stringify(data)); })
+    public sendData = (data: any): void => {
+        const stringified = JSON.stringify(Array.from(new Uint8Array(data)));
+        this.outgoingDataProducer.send(stringified);
+    }
 
     public handleKick(socket: any): void {
         logger.info("Kicking ", socket.id);
@@ -116,6 +120,15 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
 
         logger.info("Initializing WebRTC Connection");
         await startWebRTC();
+
+        this.outgoingDataTransport = await this.routers.instance.createDirectTransport();
+        const options = {
+            ordered: false,
+            label: 'outgoingProducer',
+            protocol: 'raw',
+            appData: { peerID: 'outgoingProducer' }
+        };
+        this.outgoingDataProducer = await this.outgoingDataTransport.produceData(options);
 
         setInterval(() => validateNetworkObjects(), 5000);
 


### PR DESCRIPTION
Reconfigured transports and producers/consumers so that data can be sent
to/sourced from server's message queue as the single source of truth.

Only DirectTransports can be read from/written to on the server side.
WebRTCTransports, and other transport types, cannot.
Solution was to create a DirectTransport server side. Whenever a
DataProducer is created for a client, a DataConsumer is created on the
DirectTransport that consumes that DataProducer. This DataConsumer
is used to put the messages it's getting from the DataProducer onto
the server's incoming message queue.

The server sets up a single DataProducer on the DirectTransport when it starts.
This DataProducer is always sending out the messages popped off the outgoing
message queue. When a client signals it wants to create a DataConsumer, it's
consuming this outgoing DataProducer - all clients consume the same DataProducer.

Changed how data is sent/received by producers/consumers, as JSON.stringify()
does not properly transform ArrayBuffers. Had to do it via the follwing:

const stringified = JSON.stringify(Array.from(new Uint8Array(data)));
and
const decoded = Uint8Array.from(JSON.parse(message)).buffer;

Left data transfer as reliable messaging for now pending split in
which data should be sent reliably vs. unreliably.