### PR TITLE
Bug Fix: Disable Directional Lights

### DIFF
--- a/packages/engine/src/assets/functions/LoadGLTF.ts
+++ b/packages/engine/src/assets/functions/LoadGLTF.ts
@@ -77,10 +77,7 @@ const loadLightmaps = parser => {
 // this isn't the best solution. instead we should expose the plugin/extension register in GLTFLoader.js 
 
 const loadLights = gltf => {
-    if( gltf.parser.json 
-        && gltf.parser.json.extensions
-        && gltf.parser.json.extensions.MOZ_hubs_components 
-        && gltf.parser.json.extensions.MOZ_hubs_components.version === 3) {
+    if(gltf.parser.json?.extensions?.MOZ_hubs_components?.MOZ_hubs_components.version === 3) {
 
         const objsToRemove = [];
         gltf.scene.traverse((obj) => {

--- a/packages/engine/src/common/behaviors/Object3DBehaviors.ts
+++ b/packages/engine/src/common/behaviors/Object3DBehaviors.ts
@@ -130,18 +130,18 @@ export const addObject3DComponent: Behavior = (
     applyDeepValue(object3d, key, args.objArgs[key]);
   });
   
-    object3d.traverse((obj) => {
-        // todo: add in shadow checks once we figure editor model settings
-        // if((obj.receiveShadow || obj.castShadow) && (obj.type === 'Mesh' || obj.type === 'SkinnedMesh')) {
-        if(obj.type === 'Mesh' || obj.type === 'SkinnedMesh') {
-            obj.castShadow = true;
-            // when we use lightmaps we don't want it to receive shadows from itself. this however stops other entity's shadows being cast on it
-            if(!obj.material?.userData?.gltfExtensions?.MOZ_lightmap) {
-                obj.receiveShadow = true;
-                obj.material && Engine.csm && Engine.csm.setupMaterial(obj.material);
-            }
-        }
-    });
+  object3d.traverse((obj) => {
+    // todo: add in shadow checks once we figure editor model settings
+    // if((obj.receiveShadow || obj.castShadow) && (obj.type === 'Mesh' || obj.type === 'SkinnedMesh')) {
+    if(obj.type === 'Mesh' || obj.type === 'SkinnedMesh') {
+      obj.castShadow = true;
+      // when we use lightmaps we don't want it to receive shadows from itself. this however stops other entity's shadows being cast on it
+      if(!obj.material?.userData?.gltfExtensions?.MOZ_lightmap) {
+        obj.receiveShadow = true;
+        obj.material && Engine.csm?.setupMaterial(obj.material);
+      }
+    }
+  });
 
   addComponent(entity, Object3DComponent, { value: object3d });
   // getMutableComponent<Object3DComponent>(entity, Object3DComponent).value = object3d;

--- a/packages/engine/src/scene/constants/SceneObjectLoadingSchema.ts
+++ b/packages/engine/src/scene/constants/SceneObjectLoadingSchema.ts
@@ -43,24 +43,26 @@ export const SceneObjectLoadingSchema: LoadingSchema = {
           type: LightTagComponent
         }]
   },
-  'directional-light': {
-    behaviors: [
-      {
-        behavior: addObject3DComponent,
-        args: { obj3d: DirectionalLight, objArgs: { castShadow: true } },
-        values: [
-          { from: 'shadowMapResolution', to: 'shadow.mapSize' },
-          { from: 'shadowBias', to: 'shadow.bias' },
-          { from: 'shadowRadius', to: 'shadow.radius' },
-          { from: 'intensity', to: 'intensity' },
-          { from: 'color', to: 'color' }
-        ]
-      }
-    ],
-      components: [{
-        type: LightTagComponent
-      }]
-  },
+// currently this breaks CSM
+
+//   'directional-light': {
+//     behaviors: [
+//       {
+//         behavior: addObject3DComponent,
+//         args: { obj3d: DirectionalLight, objArgs: { castShadow: true } },
+//         values: [
+//           { from: 'shadowMapResolution', to: 'shadow.mapSize' },
+//           { from: 'shadowBias', to: 'shadow.bias' },
+//           { from: 'shadowRadius', to: 'shadow.radius' },
+//           { from: 'intensity', to: 'intensity' },
+//           { from: 'color', to: 'color' }
+//         ]
+//       }
+//     ],
+//       components: [{
+//         type: LightTagComponent
+//       }]
+//   },
   'collidable': {
     components: [
       {


### PR DESCRIPTION
CSM has broken directional lights. we will disable them until three and/or three-csm integrates additional directional lights.

Only disables loading of directional lights into the location view, so locations can still be built in the editor using directional light nodes.