### PR TITLE
Fixed some bugs with users and sendData.

### DIFF
--- a/packages/client-core/redux/friend/reducers.ts
+++ b/packages/client-core/redux/friend/reducers.ts
@@ -62,7 +62,7 @@ const friendReducer = (state = immutableState, action: FriendAction): any => {
       otherUser = patchedUserRelationship.userId === selfUser.id ? patchedUserRelationship.relatedUser : patchedUserRelationship.user;
       updateMap = new Map(state.get('friends'));
       updateMapFriends = updateMap.get('friends');
-      updateMapFriendsChild = _.find(updateMapFriends, (friend: User) => friend.id === otherUser.id);
+      updateMapFriendsChild = _.find(updateMapFriends, (friend: User) => { return friend != null && (friend.id === otherUser.id)});
       if (updateMapFriendsChild != null) {
         updateMapFriends = updateMapFriends.map((friend: User) => friend.id === otherUser.id ? otherUser : friend);
       }
@@ -79,7 +79,7 @@ const friendReducer = (state = immutableState, action: FriendAction): any => {
       otherUserId = removedUserRelationship.userId === selfUser.id ? removedUserRelationship.relatedUserId : removedUserRelationship.userId;
       updateMap = new Map(state.get('friends'));
       updateMapFriends = updateMap.get('friends');
-      updateMapFriendsChild = _.find(updateMapFriends, (friend: User) => friend.id === otherUserId);
+      updateMapFriendsChild = _.find(updateMapFriends, (friend: User) => { return friend != null && (friend.id === otherUserId)});
       if (updateMapFriendsChild != null) {
         _.remove(updateMapFriends, (friend: User) => friend.id === otherUserId);
         updateMap.set('friends', updateMapFriends);

--- a/packages/client-core/redux/group/reducers.ts
+++ b/packages/client-core/redux/group/reducers.ts
@@ -87,7 +87,7 @@ const groupReducer = (state = immutableState, action: GroupAction): any => {
       updateGroup = newValues.group;
       updateMap = new Map(state.get('groups'));
       updateMapGroups = updateMap.get('groups');
-      updateMapGroupsChild = _.find(updateMapGroups, (group) => group.id === updateGroup.id);
+      updateMapGroupsChild = _.find(updateMapGroups, (group) => { return group != null && (group.id === groupUser.groupId)});
         if (updateMapGroupsChild != null) {
           updateMapGroupsChild.name = updateGroup.name;
           updateMapGroupsChild.description = updateGroup.description;
@@ -116,7 +116,7 @@ const groupReducer = (state = immutableState, action: GroupAction): any => {
       groupUser = newValues.groupUser;
       updateMap = new Map(state.get('groups'));
       updateMapGroups = updateMap.get('groups');
-      updateMapGroupsChild = _.find(updateMapGroups, (group) => group.id === groupUser.groupId);
+      updateMapGroupsChild = _.find(updateMapGroups, (group) => { return group != null && (group.id === groupUser.groupId)});
       if (updateMapGroupsChild != null) {
         updateMapGroupUsers = updateMapGroupsChild.groupUsers;
         updateMapGroupUsers = Array.isArray(updateMapGroupUsers) ? updateMapGroupUsers.concat([groupUser]) : [groupUser];
@@ -130,7 +130,7 @@ const groupReducer = (state = immutableState, action: GroupAction): any => {
       groupUser = newValues.groupUser;
       updateMap = new Map(state.get('groups'));
       updateMapGroups = updateMap.get('groups');
-      updateMapGroupsChild = _.find(updateMapGroups, (group) => group.id === groupUser.groupId);
+      updateMapGroupsChild = _.find(updateMapGroups, (group) => { return group != null && (group.id === groupUser.groupId)});
       if (updateMapGroupsChild != null) {
         // updateMapGroupUsers = updateMapGroupsChild.groupUsers
         updateMapGroupsChild.groupUsers = updateMapGroupsChild.groupUsers.map((gUser) => gUser.id === groupUser.id ? groupUser : gUser);
@@ -144,7 +144,7 @@ const groupReducer = (state = immutableState, action: GroupAction): any => {
       const self = newValues.self;
       updateMap = new Map(state.get('groups'));
       updateMapGroups = updateMap.get('groups');
-      updateMapGroupsChild = _.find(updateMapGroups, (group) => group.id === groupUser.groupId);
+      updateMapGroupsChild = _.find(updateMapGroups, (group) => { return group != null && (group.id === groupUser.groupId)});
       if (updateMapGroupsChild != null) {
         updateMapGroupUsers = updateMapGroupsChild.groupUsers;
         _.remove(updateMapGroupUsers, (gUser: GroupUser) => groupUser.id === gUser.id);

--- a/packages/client-core/redux/party/reducers.ts
+++ b/packages/client-core/redux/party/reducers.ts
@@ -50,7 +50,7 @@ const partyReducer = (state = immutableState, action: PartyAction): any => {
       updateMap = _.cloneDeep(state.get('party'));
       if (updateMap != null) {
         updateMapPartyUsers = updateMap.partyUsers;
-        updateMapPartyUsers = Array.isArray(updateMapPartyUsers) ? (updateMapPartyUsers.find(pUser => pUser.id === partyUser.id) == null ? updateMapPartyUsers.concat([partyUser]) : updateMap.partyUsers.map((pUser) => pUser.id === partyUser.id ? partyUser : pUser)) : [partyUser];
+        updateMapPartyUsers = Array.isArray(updateMapPartyUsers) ? (updateMapPartyUsers.find(pUser => { return pUser != null && (pUser.id === partyUser.id)}) == null ? updateMapPartyUsers.concat([partyUser]) : updateMap.partyUsers.map((pUser) => { return pUser != null && (pUser.id === partyUser.id) ? partyUser : pUser})) : [partyUser];
         updateMap.partyUsers = updateMapPartyUsers;
       }
 
@@ -61,7 +61,7 @@ const partyReducer = (state = immutableState, action: PartyAction): any => {
       partyUser = newValues.partyUser;
       updateMap = _.cloneDeep(state.get('party'));
       if (updateMap != null) {
-        updateMap.partyUsers = updateMap.partyUsers.map((pUser) => pUser.id === partyUser.id ? partyUser : pUser);
+        updateMap.partyUsers = updateMap.partyUsers.map((pUser) => { return pUser != null && (pUser.id === partyUser.id ? partyUser : pUser)});
       }
 
       return state
@@ -72,7 +72,7 @@ const partyReducer = (state = immutableState, action: PartyAction): any => {
       updateMap = _.cloneDeep(state.get('party'));
       if (updateMap != null) {
         updateMapPartyUsers = updateMap.partyUsers;
-        _.remove(updateMapPartyUsers, (pUser: PartyUser) => partyUser.id === pUser.id);
+        _.remove(updateMapPartyUsers, (pUser: PartyUser) => { return pUser != null && (partyUser.id === pUser.id)});
       }
       return state
           .set('party', updateMap)

--- a/packages/client-core/redux/user/reducers.ts
+++ b/packages/client-core/redux/user/reducers.ts
@@ -63,7 +63,7 @@ const userReducer = (state = immutableState, action: UserAction): any => {
     case ADDED_LAYER_USER:
       newUser = (action as AddedLayerUserAction).user;
       layerUsers = state.get('layerUsers');
-      match = layerUsers.find((layerUser) => layerUser.id === newUser.id);
+      match = layerUsers.find((layerUser) => { return layerUser != null && (layerUser.id === newUser.id)});
       if (match == null) {
         layerUsers.push(newUser);
       } else {
@@ -75,7 +75,7 @@ const userReducer = (state = immutableState, action: UserAction): any => {
     case REMOVED_LAYER_USER:
       newUser = (action as RemovedLayerUserAction).user;
       layerUsers = state.get('layerUsers');
-      layerUsers = layerUsers.filter((layerUser) => layerUser.id !== newUser.id);
+      layerUsers = layerUsers.filter((layerUser) => { return layerUser != null && (layerUser.id !== newUser.id)});
       return state
           .set('layerUsers', layerUsers);
     case CLEAR_CHANNEL_LAYER_USERS:
@@ -89,7 +89,7 @@ const userReducer = (state = immutableState, action: UserAction): any => {
     case ADDED_CHANNEL_LAYER_USER:
       newUser = (action as AddedLayerUserAction).user;
       layerUsers = state.get('channelLayerUsers');
-      match = layerUsers.find((layerUser) => layerUser.id === newUser.id);
+      match = layerUsers.find((layerUser) => { return layerUser != null && (layerUser.id === newUser.id)});
       if (match == null) {
         layerUsers.push(newUser);
       } else {
@@ -101,7 +101,7 @@ const userReducer = (state = immutableState, action: UserAction): any => {
     case REMOVED_CHANNEL_LAYER_USER:
       newUser = (action as RemovedLayerUserAction).user;
       layerUsers = state.get('channelLayerUsers');
-      layerUsers = layerUsers.filter((layerUser) => layerUser.id !== newUser.id);
+      layerUsers = layerUsers.filter((layerUser) => { return layerUser != null && (layerUser.id !== newUser.id)});
       return state
           .set('channelLayerUsers', layerUsers);
     case USER_TOAST:

--- a/packages/engine/src/networking/classes/SocketWebRTCClientTransport.ts
+++ b/packages/engine/src/networking/classes/SocketWebRTCClientTransport.ts
@@ -66,12 +66,16 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
   // This sends message on a data channel (data channel creation is now handled explicitly/default)
   sendData(data: any, instance = true): void {
     if (instance === true) {
-      if (!this.instanceDataProducer)
-        throw new Error('Data Producer not initialized on client, Instance Data Producer doesn\'t exist!');
+      if (!this.instanceDataProducer) {
+        console.error('Data Producer not initialized on client, Instance Data Producer doesn\'t exist!');
+        return;
+      }
       if (this.instanceDataProducer.closed !== true) this.instanceDataProducer.send(this.toBuffer(data));
     } else {
-      if (!this.channelDataProducer)
-        throw new Error('Data Producer not initialized on client, Channel Data Producer doesn\'t exist!');
+      if (!this.channelDataProducer) {
+        console.error('Data Producer not initialized on client, Channel Data Producer doesn\'t exist!');
+        return;
+      }
       if (this.channelDataProducer.closed !== true) this.channelDataProducer.send(this.toBuffer(data));
     }
   }


### PR DESCRIPTION
Patches to groupUsers, partyUsers, layerUsers, and friends could come in before the
redux state array has been fully initialized. Errors were being thrown at times due
to _.find's on a group trying to match group.id when group was undefined. Made these
comparisons explicitly check that the items in the list/array were not null before
matching their id.

sendData is sometimes getting called before dataProducers have been instantiated.
The old behavior was to throw an error; switched to doing console.error and returning
from the function, skipping any attempt to actually do the send.