### PR TITLE
Fixed some bugs with Harmony rendering and connecting.

### DIFF
--- a/packages/client-core/components/ui/PartyParticipantWindow/index.tsx
+++ b/packages/client-core/components/ui/PartyParticipantWindow/index.tsx
@@ -214,10 +214,10 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
             if (audioStream != null) {
                 audioRef.current.srcObject = new MediaStream([audioStream.track.clone()]);
                 if (peerId !== 'me_cam') {
-                    console.log("*** New mediastream created for audio track for peer id ", peerId);
+                    // console.log("*** New mediastream created for audio track for peer id ", peerId);
                     // Create positional audio and attach mediastream here
-                    console.log("MediaStreamSystem.instance?.consumers is ");
-                    console.log(MediaStreamSystem.instance?.consumers);
+                    // console.log("MediaStreamSystem.instance?.consumers is ");
+                    // console.log(MediaStreamSystem.instance?.consumers);
                 }
                 if (peerId === 'me_cam') {
                     MediaStreamSystem.instance.setAudioPaused(false);

--- a/packages/client-core/components/ui/PartyVideoWindows/index.tsx
+++ b/packages/client-core/components/ui/PartyVideoWindows/index.tsx
@@ -43,11 +43,8 @@ const PartyVideoWindows = (props: Props): JSX.Element => {
   const channelLayerUsers = userState.get('channelLayerUsers') ?? [];
 
   useEffect(() => {
-    console.log('transport channelType:', (Network.instance?.transport as any)?.channelType);
     if ((Network.instance?.transport as any)?.channelType === 'channel') setDisplayedUsers(channelLayerUsers.filter((user) => user.id !== selfUser.id));
     else setDisplayedUsers(layerUsers.filter((user) => user.id !== selfUser.id))
-    console.log('displayedUsers:');
-    console.log(displayedUsers);
   }, [layerUsers, channelLayerUsers]);
 
   const [ expanded, setExpanded ] = useState(true);

--- a/packages/client-core/redux/channelConnection/reducers.ts
+++ b/packages/client-core/redux/channelConnection/reducers.ts
@@ -47,9 +47,7 @@ const channelConnectionReducer = (state = immutableState, action: ChannelServerA
           .set('readyToConnect', false)
           .set('instanceProvisioning', true);
     case CHANNEL_SERVER_PROVISIONED:
-      console.log('CHANNEL_SERVER_PROVISIONED REDUCER');
       newInstance = new Map(state.get('instance'));
-      console.log(newInstance);
       newValues = (action as ChannelServerProvisionedAction);
       newInstance.set('ipAddress', newValues.ipAddress);
       newInstance.set('port', newValues.port);
@@ -71,7 +69,6 @@ const channelConnectionReducer = (state = immutableState, action: ChannelServerA
           .set('updateNeeded', false)
           .set('readyToConnect', false);
     case CHANNEL_SERVER_DISCONNECTED:
-      console.log('CHANNEL_SERVER_DISCONNECTED');
       if (connectionSocket != null) (connectionSocket as any).close();
       const newState = state
           .set('connected', initialState.connected)
@@ -84,8 +81,6 @@ const channelConnectionReducer = (state = immutableState, action: ChannelServerA
           .set('locationId', initialState.locationId)
           .set('sceneId', initialState.sceneId)
           .set('channelId', initialState.channelId);
-      console.log('Reset state:');
-      console.log(newState);
       return newState;
     case SOCKET_CREATED:
       if (connectionSocket != null) (connectionSocket as any).close();

--- a/packages/client-core/redux/instanceConnection/reducers.ts
+++ b/packages/client-core/redux/instanceConnection/reducers.ts
@@ -47,7 +47,6 @@ const instanceConnectionReducer = (state = immutableState, action: InstanceServe
           .set('readyToConnect', false)
           .set('instanceProvisioning', true);
     case INSTANCE_SERVER_PROVISIONED:
-      console.log('INSTANCE_SERVER_PROVISIONED REDUCER');
       newInstance = new Map(state.get('instance'));
       newValues = (action as InstanceServerProvisionedAction);
       newInstance.set('ipAddress', newValues.ipAddress);
@@ -71,7 +70,6 @@ const instanceConnectionReducer = (state = immutableState, action: InstanceServe
         .set('updateNeeded', false)
         .set('readyToConnect', false);
     case INSTANCE_SERVER_DISCONNECTED:
-      console.log('INSTANCE_SERVER_DISCONNECTED');
       if (connectionSocket != null) (connectionSocket as any).close();
       return state
         .set('connected', initialState.connected)

--- a/packages/client-core/redux/instanceConnection/service.ts
+++ b/packages/client-core/redux/instanceConnection/service.ts
@@ -35,8 +35,6 @@ export function provisionInstanceServer(locationId?: string, instanceId?: string
         token: token
       }
     });
-    console.log('Instance Provision result:');
-    console.log(provisionResult);
     if (provisionResult.ipAddress != null && provisionResult.port != null) {
       dispatch(instanceServerProvisioned(provisionResult, locationId, sceneId));
     }
@@ -47,7 +45,6 @@ export function connectToInstanceServer(channelType: string, channelId?: string)
   return async (dispatch: Dispatch, getState: any): Promise<any> => {
     try {
       dispatch(instanceServerConnecting());
-      console.log('connectToInstanceServer: ', channelType, channelId);
       const authState = getState().get('auth');
       const user = authState.get('user');
       const token = authState.get('authUser').accessToken;
@@ -92,7 +89,5 @@ export function resetInstanceServer() {
 }
 
 client.service('instance-provision').on('created', (params) => {
-  console.log('instanceConnection instance-provision listener');
-  console.log(params);
   if (params.locationId != null) store.dispatch(instanceServerProvisioned(params, params.locationId, params.sceneId));
 });

--- a/packages/client-core/redux/location/service.ts
+++ b/packages/client-core/redux/location/service.ts
@@ -32,8 +32,6 @@ export function getLocation(locationId: string) {
     try {
       dispatch(fetchingCurrentLocation());
       const location = await client.service('location').get(locationId);
-      console.log('getLocation location:');
-      console.log(location);
       dispatch(locationRetrieved(location));
     } catch(err) {
       console.log(err);
@@ -43,7 +41,6 @@ export function getLocation(locationId: string) {
 }
 
 export function getLocationByName(locationName: string) {
-  console.log("Trying to get location by name", locationName);
   return async (dispatch: Dispatch): Promise<any> => {
       const locationResult = await client.service('location').find({
         query: {

--- a/packages/engine/src/common/classes/BufferGeometryUtils.ts
+++ b/packages/engine/src/common/classes/BufferGeometryUtils.ts
@@ -22,24 +22,24 @@ import {
 	 */
 	 export function  mergeBufferGeometries ( geometries, useGroups? ) {
 
-		var isIndexed = geometries[ 0 ].index !== null;
+		const isIndexed = geometries[ 0 ].index !== null;
 
-		var attributesUsed = new Set( Object.keys( geometries[ 0 ].attributes ) );
-		var morphAttributesUsed = new Set( Object.keys( geometries[ 0 ].morphAttributes ) );
+		const attributesUsed = new Set( Object.keys( geometries[ 0 ].attributes ) );
+		const morphAttributesUsed = new Set( Object.keys( geometries[ 0 ].morphAttributes ) );
 
-		var attributes = {};
-		var morphAttributes = {};
+		const attributes = {};
+		const morphAttributes = {};
 
-		var morphTargetsRelative = geometries[ 0 ].morphTargetsRelative;
+		const morphTargetsRelative = geometries[ 0 ].morphTargetsRelative;
 
-		var mergedGeometry = new BufferGeometry();
+		const mergedGeometry = new BufferGeometry();
 
-		var offset = 0;
+		let offset = 0;
 
-		for ( var i = 0; i < geometries.length; ++ i ) {
+		for ( let i = 0; i < geometries.length; ++ i ) {
 
-			var geometry = geometries[ i ];
-			var attributesCount = 0;
+			const geometry = geometries[ i ];
+			let attributesCount = 0;
 
 			// ensure that all geometries are indexed, or none
 
@@ -52,7 +52,7 @@ import {
 
 			// gather attributes, exit early if they're different
 
-			for ( var name in geometry.attributes ) {
+			for ( const name in geometry.attributes ) {
 
 				if ( ! attributesUsed.has( name ) ) {
 
@@ -87,7 +87,7 @@ import {
 
 			}
 
-			for ( var name in geometry.morphAttributes ) {
+			for ( const name in geometry.morphAttributes ) {
 
 				if ( ! morphAttributesUsed.has( name ) ) {
 
@@ -109,7 +109,7 @@ import {
 
 			if ( useGroups ) {
 
-				var count;
+				let count;
 
 				if ( isIndexed ) {
 
@@ -138,14 +138,14 @@ import {
 
 		if ( isIndexed ) {
 
-			var indexOffset = 0;
-			var mergedIndex = [];
+			let indexOffset = 0;
+			const mergedIndex = [];
 
-			for ( var i = 0; i < geometries.length; ++ i ) {
+			for ( let i = 0; i < geometries.length; ++ i ) {
 
-				var index = geometries[ i ].index;
+				const index = geometries[ i ].index;
 
-				for ( var j = 0; j < index.count; ++ j ) {
+				for ( let j = 0; j < index.count; ++ j ) {
 
 					mergedIndex.push( index.getX( j ) + indexOffset );
 
@@ -161,9 +161,9 @@ import {
 
 		// merge attributes
 
-		for ( var name in attributes ) {
+		for ( const name in attributes ) {
 
-			var mergedAttribute = mergeBufferAttributes( attributes[ name ] );
+			const mergedAttribute = mergeBufferAttributes( attributes[ name ] );
 
 			if ( ! mergedAttribute ) {
 
@@ -178,26 +178,26 @@ import {
 
 		// merge morph attributes
 
-		for ( var name in morphAttributes ) {
+		for ( const name in morphAttributes ) {
 
-			var numMorphTargets = morphAttributes[ name ][ 0 ].length;
+			const numMorphTargets = morphAttributes[ name ][ 0 ].length;
 
 			if ( numMorphTargets === 0 ) break;
 
 			mergedGeometry.morphAttributes = mergedGeometry.morphAttributes || {};
 			mergedGeometry.morphAttributes[ name ] = [];
 
-			for ( var i = 0; i < numMorphTargets; ++ i ) {
+			for ( let i = 0; i < numMorphTargets; ++ i ) {
 
-				var morphAttributesToMerge = [];
+				const morphAttributesToMerge = [];
 
-				for ( var j = 0; j < morphAttributes[ name ].length; ++ j ) {
+				for ( let j = 0; j < morphAttributes[ name ].length; ++ j ) {
 
 					morphAttributesToMerge.push( morphAttributes[ name ][ j ][ i ] );
 
 				}
 
-				var mergedMorphAttribute = mergeBufferAttributes( morphAttributesToMerge );
+				const mergedMorphAttribute = mergeBufferAttributes( morphAttributesToMerge );
 
 				if ( ! mergedMorphAttribute ) {
 
@@ -222,14 +222,14 @@ import {
 	 */
 	 export function mergeBufferAttributes ( attributes ) {
 
-		var TypedArray;
-		var itemSize;
-		var normalized;
-		var arrayLength = 0;
+		let TypedArray;
+		let itemSize;
+		let normalized;
+		let arrayLength = 0;
 
-		for ( var i = 0; i < attributes.length; ++ i ) {
+		for ( let i = 0; i < attributes.length; ++ i ) {
 
-			var attribute = attributes[ i ];
+			const attribute = attributes[ i ];
 
 			if ( attribute.isInterleavedBufferAttribute ) {
 
@@ -266,10 +266,10 @@ import {
 
 		}
 
-		var array = new TypedArray( arrayLength );
-		var offset = 0;
+		const array = new TypedArray( arrayLength );
+		let offset = 0;
 
-		for ( var i = 0; i < attributes.length; ++ i ) {
+		for ( let i = 0; i < attributes.length; ++ i ) {
 
 			array.set( attributes[ i ].array, offset );
 
@@ -289,14 +289,14 @@ import {
 
 		// Interleaves the provided attributes into an InterleavedBuffer and returns
 		// a set of InterleavedBufferAttributes for each attribute
-		var TypedArray;
-		var arrayLength = 0;
-		var stride = 0;
+		let TypedArray;
+		let arrayLength = 0;
+		let stride = 0;
 
 		// calculate the the length and type of the interleavedBuffer
-		for ( var i = 0, l = attributes.length; i < l; ++ i ) {
+		for ( let i = 0, l = attributes.length; i < l; ++ i ) {
 
-			var attribute = attributes[ i ];
+			const attribute = attributes[ i ];
 
 			if ( TypedArray === undefined ) TypedArray = attribute.array.constructor;
 			if ( TypedArray !== attribute.array.constructor ) {
@@ -312,27 +312,27 @@ import {
 		}
 
 		// Create the set of buffer attributes
-		var interleavedBuffer = new InterleavedBuffer( new TypedArray( arrayLength ), stride );
-		var offset = 0;
-		var res = [];
-		var getters = [ 'getX', 'getY', 'getZ', 'getW' ];
-		var setters = [ 'setX', 'setY', 'setZ', 'setW' ];
+		const interleavedBuffer = new InterleavedBuffer( new TypedArray( arrayLength ), stride );
+		let offset = 0;
+		const res = [];
+		const getters = [ 'getX', 'getY', 'getZ', 'getW' ];
+		const setters = [ 'setX', 'setY', 'setZ', 'setW' ];
 
-		for ( var j = 0, l = attributes.length; j < l; j ++ ) {
+		for ( let j = 0, l = attributes.length; j < l; j ++ ) {
 
-			var attribute = attributes[ j ];
-			var itemSize = attribute.itemSize;
-			var count = attribute.count;
-			var iba = new InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, attribute.normalized );
+			const attribute = attributes[ j ];
+			const itemSize = attribute.itemSize;
+			const count = attribute.count;
+			const iba = new InterleavedBufferAttribute( interleavedBuffer, itemSize, offset, attribute.normalized );
 			res.push( iba );
 
 			offset += itemSize;
 
 			// Move the data for each attribute into the new interleavedBuffer
 			// at the appropriate offset
-			for ( var c = 0; c < count; c ++ ) {
+			for ( let c = 0; c < count; c ++ ) {
 
-				for ( var k = 0; k < itemSize; k ++ ) {
+				for ( let k = 0; k < itemSize; k ++ ) {
 
 					iba[ setters[ k ] ]( c, attribute[ getters[ k ] ]( c ) );
 
@@ -355,15 +355,15 @@ import {
 		// Return the estimated memory used by this geometry in bytes
 		// Calculate using itemSize, count, and BYTES_PER_ELEMENT to account
 		// for InterleavedBufferAttributes.
-		var mem = 0;
-		for ( var name in geometry.attributes ) {
+		let mem = 0;
+		for ( const name in geometry.attributes ) {
 
-			var attr = geometry.getAttribute( name );
+			const attr = geometry.getAttribute( name );
 			mem += attr.count * attr.itemSize * attr.array.BYTES_PER_ELEMENT;
 
 		}
 
-		var indices = geometry.getIndex();
+		const indices = geometry.getIndex();
 		mem += indices ? indices.count * indices.itemSize * indices.array.BYTES_PER_ELEMENT : 0;
 		return mem;
 
@@ -380,29 +380,29 @@ import {
 
 		// Generate an index buffer if the geometry doesn't have one, or optimize it
 		// if it's already available.
-		var hashToIndex = {};
-		var indices = geometry.getIndex();
-		var positions = geometry.getAttribute( 'position' );
-		var vertexCount = indices ? indices.count : positions.count;
+		const hashToIndex = {};
+		const indices = geometry.getIndex();
+		const positions = geometry.getAttribute( 'position' );
+		const vertexCount = indices ? indices.count : positions.count;
 
 		// next value for triangle indices
-		var nextIndex = 0;
+		let nextIndex = 0;
 
 		// attributes and new attribute arrays
-		var attributeNames = Object.keys( geometry.attributes );
-		var attrArrays = {};
-		var morphAttrsArrays = {};
-		var newIndices = [];
-		var getters = [ 'getX', 'getY', 'getZ', 'getW' ];
+		const attributeNames = Object.keys( geometry.attributes );
+		const attrArrays = {};
+		const morphAttrsArrays = {};
+		const newIndices = [];
+		const getters = [ 'getX', 'getY', 'getZ', 'getW' ];
 
 		// initialize the arrays
-		for ( var i = 0, l = attributeNames.length; i < l; i ++ ) {
+		for ( let i = 0, l = attributeNames.length; i < l; i ++ ) {
 
-			var name = attributeNames[ i ];
+			const name = attributeNames[ i ];
 
 			attrArrays[ name ] = [];
 
-			var morphAttr = geometry.morphAttributes[ name ];
+			const morphAttr = geometry.morphAttributes[ name ];
 			if ( morphAttr ) {
 
 				morphAttrsArrays[ name ] = new Array( morphAttr.length ).fill(0).map( () => [] );
@@ -412,21 +412,21 @@ import {
 		}
 
 		// convert the error tolerance to an amount of decimal places to truncate to
-		var decimalShift = Math.log10( 1 / tolerance );
-		var shiftMultiplier = Math.pow( 10, decimalShift );
-		for ( var i = 0; i < vertexCount; i ++ ) {
+		const decimalShift = Math.log10( 1 / tolerance );
+		const shiftMultiplier = Math.pow( 10, decimalShift );
+		for ( let i = 0; i < vertexCount; i ++ ) {
 
-			var index = indices ? indices.getX( i ) : i;
+			const index = indices ? indices.getX( i ) : i;
 
 			// Generate a hash for the vertex attributes at the current index 'i'
-			var hash = '';
-			for ( var j = 0, l = attributeNames.length; j < l; j ++ ) {
+			let hash = '';
+			for ( let j = 0, l = attributeNames.length; j < l; j ++ ) {
 
-				var name = attributeNames[ j ];
-				var attribute = geometry.getAttribute( name );
-				var itemSize = attribute.itemSize;
+				const name = attributeNames[ j ];
+				const attribute = geometry.getAttribute( name );
+				const itemSize = attribute.itemSize;
 
-				for ( var k = 0; k < itemSize; k ++ ) {
+				for ( let k = 0; k < itemSize; k ++ ) {
 
 					// double tilde truncates the decimal value
 					hash += `${ ~ ~ ( attribute[ getters[ k ] ]( index ) * shiftMultiplier ) },`;
@@ -444,23 +444,23 @@ import {
 			} else {
 
 				// copy data to the new index in the attribute arrays
-				for ( var j = 0, l = attributeNames.length; j < l; j ++ ) {
+				for ( let j = 0, l = attributeNames.length; j < l; j ++ ) {
 
-					var name = attributeNames[ j ];
-					var attribute = geometry.getAttribute( name );
-					var morphAttr = geometry.morphAttributes[ name ];
-					var itemSize = attribute.itemSize;
-					var newarray = attrArrays[ name ];
-					var newMorphArrays = morphAttrsArrays[ name ];
+					const name = attributeNames[ j ];
+					const attribute = geometry.getAttribute( name );
+					const morphAttr = geometry.morphAttributes[ name ];
+					const itemSize = attribute.itemSize;
+					const newarray = attrArrays[ name ];
+					const newMorphArrays = morphAttrsArrays[ name ];
 
-					for ( var k = 0; k < itemSize; k ++ ) {
+					for ( let k = 0; k < itemSize; k ++ ) {
 
-						var getterFunc = getters[ k ];
+						const getterFunc = getters[ k ];
 						newarray.push( attribute[ getterFunc ]( index ) );
 
 						if ( morphAttr ) {
 
-							for ( var m = 0, ml = morphAttr.length; m < ml; m ++ ) {
+							for ( let m = 0, ml = morphAttr.length; m < ml; m ++ ) {
 
 								newMorphArrays[ m ].push( morphAttr[ m ][ getterFunc ]( index ) );
 
@@ -483,25 +483,25 @@ import {
 		// Generate typed arrays from new attribute arrays and update
 		// the attributeBuffers
 		const result = geometry.clone();
-		for ( var i = 0, l = attributeNames.length; i < l; i ++ ) {
+		for ( let i = 0, l = attributeNames.length; i < l; i ++ ) {
 
-			var name = attributeNames[ i ];
-			var oldAttribute = geometry.getAttribute( name );
+			const name = attributeNames[ i ];
+			const oldAttribute = geometry.getAttribute( name );
 
-			var buffer = new oldAttribute.array.constructor( attrArrays[ name ] );
-			let attribute = new BufferAttribute( buffer, oldAttribute.itemSize, oldAttribute.normalized );
+			const buffer = new oldAttribute.array.constructor( attrArrays[ name ] );
+			const attribute = new BufferAttribute( buffer, oldAttribute.itemSize, oldAttribute.normalized );
 
 			result.setAttribute( name, (attribute as any) );
 
 			// Update the attribute arrays
 			if ( name in morphAttrsArrays ) {
 
-				for ( var j = 0; j < morphAttrsArrays[ name ].length; j ++ ) {
+				for ( let j = 0; j < morphAttrsArrays[ name ].length; j ++ ) {
 
-					var oldMorphAttribute = geometry.morphAttributes[ name ][ j ];
+					const oldMorphAttribute = geometry.morphAttributes[ name ][ j ];
 
-					var buffer = new oldMorphAttribute.array.constructor( morphAttrsArrays[ name ][ j ] );
-					var morphAttribute = new BufferAttribute( buffer, oldMorphAttribute.itemSize, oldMorphAttribute.normalized );
+					const buffer = new oldMorphAttribute.array.constructor( morphAttrsArrays[ name ][ j ] );
+					const morphAttribute = new BufferAttribute( buffer, oldMorphAttribute.itemSize, oldMorphAttribute.normalized );
 					result.morphAttributes[ name ][ j ] = morphAttribute;
 
 				}
@@ -534,19 +534,19 @@ import {
 
 		if ( drawMode === TriangleFanDrawMode || drawMode === TriangleStripDrawMode ) {
 
-			var index = geometry.getIndex();
+			let index = geometry.getIndex();
 
 			// generate index if not present
 
 			if ( index === null ) {
 
-				var indices = [];
+				const indices = [];
 
-				var position = geometry.getAttribute( 'position' );
+				const position = geometry.getAttribute( 'position' );
 
 				if ( position !== undefined ) {
 
-					for ( var i = 0; i < position.count; i ++ ) {
+					for ( let i = 0; i < position.count; i ++ ) {
 
 						indices.push( i );
 
@@ -566,14 +566,14 @@ import {
 
 			//
 
-			var numberOfTriangles = index.count - 2;
-			var newIndices = [];
+			const numberOfTriangles = index.count - 2;
+			const newIndices = [];
 
 			if ( drawMode === TriangleFanDrawMode ) {
 
 				// gl.TRIANGLE_FAN
 
-				for ( var i = 1; i <= numberOfTriangles; i ++ ) {
+				for ( let i = 1; i <= numberOfTriangles; i ++ ) {
 
 					newIndices.push( index.getX( 0 ) );
 					newIndices.push( index.getX( i ) );
@@ -585,7 +585,7 @@ import {
 
 				// gl.TRIANGLE_STRIP
 
-				for ( var i = 0; i < numberOfTriangles; i ++ ) {
+				for ( let i = 0; i < numberOfTriangles; i ++ ) {
 
 					if ( i % 2 === 0 ) {
 
@@ -613,7 +613,7 @@ import {
 
 			// build final geometry
 
-			var newGeometry = geometry.clone();
+			const newGeometry = geometry.clone();
 			newGeometry.setIndex( newIndices );
 			newGeometry.clearGroups();
 
@@ -643,17 +643,17 @@ import {
 
 		}
 
-		var _vA = new Vector3();
-		var _vB = new Vector3();
-		var _vC = new Vector3();
+		const _vA = new Vector3();
+		const _vB = new Vector3();
+		const _vC = new Vector3();
 
-		var _tempA = new Vector3();
-		var _tempB = new Vector3();
-		var _tempC = new Vector3();
+		const _tempA = new Vector3();
+		const _tempB = new Vector3();
+		const _tempC = new Vector3();
 
-		var _morphA = new Vector3();
-		var _morphB = new Vector3();
-		var _morphC = new Vector3();
+		const _morphA = new Vector3();
+		const _morphB = new Vector3();
+		const _morphC = new Vector3();
 
 		function _calculateMorphedAttributeData(
 			object,
@@ -671,7 +671,7 @@ import {
 			_vB.fromBufferAttribute( attribute, b );
 			_vC.fromBufferAttribute( attribute, c );
 
-			var morphInfluences = object.morphTargetInfluences;
+			const morphInfluences = object.morphTargetInfluences;
 
 			if ( material.morphTargets && morphAttribute && morphInfluences ) {
 
@@ -679,16 +679,16 @@ import {
 				_morphB.set( 0, 0, 0 );
 				_morphC.set( 0, 0, 0 );
 
-				for ( var i = 0, il = morphAttribute.length; i < il; i ++ ) {
+				for ( let i = 0, il = morphAttribute.length; i < il; i ++ ) {
 
-					var influence = morphInfluences[ i ];
-					var morphAttribute = morphAttribute[ i ];
+					const influence = morphInfluences[ i ];
+					const morphAttributeLocal = morphAttribute[ i ];
 
 					if ( influence === 0 ) continue;
 
-					_tempA.fromBufferAttribute( morphAttribute, a );
-					_tempB.fromBufferAttribute( morphAttribute, b );
-					_tempC.fromBufferAttribute( morphAttribute, c );
+					_tempA.fromBufferAttribute( morphAttributeLocal, a );
+					_tempB.fromBufferAttribute( morphAttributeLocal, b );
+					_tempC.fromBufferAttribute( morphAttributeLocal, c );
 
 					if ( morphTargetsRelative ) {
 
@@ -732,25 +732,25 @@ import {
 
 		}
 
-		var geometry = object.geometry;
-		var material = object.material;
+		const geometry = object.geometry;
+		const material = object.material;
 
-		var a, b, c;
-		var index = geometry.index;
-		var positionAttribute = geometry.attributes.position;
-		var morphPosition = geometry.morphAttributes.position;
-		var morphTargetsRelative = geometry.morphTargetsRelative;
-		var normalAttribute = geometry.attributes.normal;
-		var morphNormal = geometry.morphAttributes.position;
+		let a, b, c;
+		const index = geometry.index;
+		const positionAttribute = geometry.attributes.position;
+		const morphPosition = geometry.morphAttributes.position;
+		const morphTargetsRelative = geometry.morphTargetsRelative;
+		const normalAttribute = geometry.attributes.normal;
+		const morphNormal = geometry.morphAttributes.position;
 
-		var groups = geometry.groups;
-		var drawRange = geometry.drawRange;
-		var i, j, il, jl;
-		var group, groupMaterial;
-		var start, end;
+		const groups = geometry.groups;
+		const drawRange = geometry.drawRange;
+		let i, j, il, jl;
+		let group, groupMaterial;
+		let start, end;
 
-		var modifiedPosition = new Float32Array( positionAttribute.count * positionAttribute.itemSize );
-		var modifiedNormal = new Float32Array( normalAttribute.count * normalAttribute.itemSize );
+		const modifiedPosition = new Float32Array( positionAttribute.count * positionAttribute.itemSize );
+		const modifiedNormal = new Float32Array( normalAttribute.count * normalAttribute.itemSize );
 
 		if ( index !== null ) {
 
@@ -912,8 +912,8 @@ import {
 
 		}
 
-		var morphedPositionAttribute = new Float32BufferAttribute( modifiedPosition, 3 );
-		var morphedNormalAttribute = new Float32BufferAttribute( modifiedNormal, 3 );
+		const morphedPositionAttribute = new Float32BufferAttribute( modifiedPosition, 3 );
+		const morphedNormalAttribute = new Float32BufferAttribute( modifiedNormal, 3 );
 
 		return {
 

--- a/packages/engine/src/ecs/classes/Engine.ts
+++ b/packages/engine/src/ecs/classes/Engine.ts
@@ -223,9 +223,9 @@ export class Engine {
 
   static createElement: any = createElement;
 
-  static hasUserEngaged: boolean = false;
+  static hasUserEngaged = false;
 
-  static useAudioSystem: boolean = false;
+  static useAudioSystem = false;
 
   static inputState = new Map();
   static prevInputState = new Map();
@@ -238,8 +238,8 @@ export class Engine {
    * @property {Binary[]} gamepadButtons Map gamepad buttons
    * @property {Number[]} gamepadInput Map gamepad buttons to abstract input
    */
-  static gamepadConnected: boolean = false;
-  static gamepadThreshold: number = 0.1;
+  static gamepadConnected = false;
+  static gamepadThreshold = 0.1;
   static gamepadButtons: BinaryType[] = [];
   static gamepadInput: number[] = [];
 }

--- a/packages/engine/src/networking/classes/SocketWebRTCClientTransport.ts
+++ b/packages/engine/src/networking/classes/SocketWebRTCClientTransport.ts
@@ -155,9 +155,6 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
       console.log(ConnectToWorldResponse);
       const { worldState, routerRtpCapabilities } = ConnectToWorldResponse as any;
 
-      console.log('EngineEvents:');
-      console.log(EngineEvents.instance);
-      console.log(EngineEvents.instance.dispatchEvent);
       EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.CONNECT_TO_WORLD });
 
       // Send heartbeat every second
@@ -251,6 +248,8 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
 
       // Init Receive and Send Transports initially since we need them for unreliable message consumption and production
       if ((socket as any).instance === true) {
+        console.log('Initializing instance transports');
+        console.log(socket);
         await Promise.all([initSendTransport('instance'), initReceiveTransport('instance')]);
         await createDataProducer((socket as any).instance === true ? 'instance' : this.channelId );
       }

--- a/packages/engine/src/networking/functions/SocketWebRTCClientFunctions.ts
+++ b/packages/engine/src/networking/functions/SocketWebRTCClientFunctions.ts
@@ -97,7 +97,6 @@ export async function createTransport(direction: string, channelType?: string, c
                     paused,
                     appData
                 });
-                console.log('Got new producer: ' + id);
                 if (error) {
                     errback();
                     console.log(error);

--- a/packages/engine/src/networking/systems/MediaStreamSystem.ts
+++ b/packages/engine/src/networking/systems/MediaStreamSystem.ts
@@ -216,24 +216,17 @@ export class MediaStreamSystem extends System {
    * @param peerId ID to be used to find peer element in which media stream will be added.
    */
   static addVideoAudio (mediaStream: { track: { clone: () => MediaStreamTrack }; kind: string }, peerId: any): void {
-    console.log('addVideoAudio');
-    console.log(mediaStream);
-    console.log(peerId);
     if (!(mediaStream && mediaStream.track)) {
       return;
     }
     const elementID = `${peerId}_${mediaStream.kind}`;
-    console.log(`elementId: ${elementID}`);
     let el = document.getElementById(elementID) as any;
-    console.log(el);
 
     // set some attributes on our audio and video elements to make
     // mobile Safari happy. note that for audio to play you need to be
     // capturing from the mic/camera
     if (mediaStream.kind === 'video') {
-      console.log('Creating video element with ID ' + elementID);
       if (el === null) {
-        console.log(`Creating video element for user with ID: ${peerId}`);
         el = document.createElement('video');
         el.id = `${peerId}_${mediaStream.kind}`;
         el.autoplay = true;
@@ -242,18 +235,9 @@ export class MediaStreamSystem extends System {
       }
 
       // TODO: do i need to update video width and height? or is that based on stream...?
-      console.log(`Updating video source for user with ID: ${peerId}`);
-      console.log('mediaStream track:');
-      console.log(mediaStream.track);
-      console.log('mediaStream track clone:');
-      console.log(mediaStream.track.clone());
       el.srcObject = new MediaStream([mediaStream.track.clone()]);
-      console.log('srcObject:');
-      console.log(el.srcObject.getTracks());
       el.mediaStream = mediaStream;
 
-      console.log('video el before play:');
-      console.log(el);
       // let's "yield" and return before playing, rather than awaiting on
       // play() succeeding. play() will not succeed on a producer-paused
       // track until the producer unpauses.
@@ -270,7 +254,6 @@ export class MediaStreamSystem extends System {
       // Positional Audio Works in Firefox:
       // Global Audio:
       if (el === null) {
-        console.log(`Creating audio element for user with ID: ${peerId}`);
         el = document.createElement('audio');
         el.id = `${peerId}_${mediaStream.kind}`;
         document.body.appendChild(el);
@@ -278,7 +261,6 @@ export class MediaStreamSystem extends System {
         el.setAttribute('autoplay', 'true');
       }
 
-      console.log(`Updating <audio> source object for client with ID: ${peerId}`);
       el.srcObject = new MediaStream([mediaStream.track.clone()]);
       el.mediaStream = mediaStream;
       el.volume = 0; // start at 0 and let the three.js scene take over from here...

--- a/packages/engine/src/templates/character/components/CharacterComponent.ts
+++ b/packages/engine/src/templates/character/components/CharacterComponent.ts
@@ -69,7 +69,7 @@ export class CharacterComponent extends Component<CharacterComponent> {
 	public defaultRotationSimulatorMass = 10;
 	public rotationSimulator: RelativeSpringSimulator;
 	public viewVector: Vector3;
-	public changedViewAngle: number = 0;
+	public changedViewAngle = 0;
 	public actions: any;
 	public actorCapsule: CapsuleCollider;
 

--- a/packages/engine/src/worker/Audio.ts
+++ b/packages/engine/src/worker/Audio.ts
@@ -16,7 +16,7 @@ class AudioGainProxy {
 class AudioPannerProxy {
 
   gain: any;
-  panningModel: string = 'HRTF';
+  panningModel = 'HRTF';
   refDistance: number;
   rolloffFactor: number;
   maxDistance: number;

--- a/packages/engine/src/worker/MessageQueue.ts
+++ b/packages/engine/src/worker/MessageQueue.ts
@@ -408,7 +408,7 @@ const audioRemoteFunctionCalls: string[] = ['play', 'pause'];
 export class AudioDocumentElementProxy extends DocumentElementProxy {
   _src: string;
   _autoplay: string;
-  _isPlaying: boolean = false;
+  _isPlaying = false;
   constructor({
     messageQueue,
     type = 'audio',

--- a/packages/engine/src/xr/SkeletonUtils.ts
+++ b/packages/engine/src/xr/SkeletonUtils.ts
@@ -17,7 +17,7 @@ function fixSkeletonZForward(rootBone, context) {
   context = context || {};
   precalculateZForwards(rootBone, context);
   if (context.exclude) {
-    var bones = [rootBone];
+    const bones = [rootBone];
     rootBone.traverse((b) => bones.push(b));
     bones.forEach((b) => {
       if (~context.exclude.indexOf(b.id) || ~context.exclude.indexOf(b.name)) {
@@ -61,11 +61,11 @@ function setZForward(rootBone, context) {
 }
 
 function calculateAverages(parentBone, worldPos, averagedDirs) {
-  var averagedDir = new Vector3();
+  const averagedDir = new Vector3();
   const childBones = parentBone.children.filter(c => c.isBone);
   childBones.forEach((childBone) => {
     //average the child bone world pos
-    var childBonePosWorld = worldPos[childBone.id][0];
+    const childBonePosWorld = worldPos[childBone.id][0];
     averagedDir.add(childBonePosWorld);
   });
 
@@ -79,7 +79,7 @@ function calculateAverages(parentBone, worldPos, averagedDirs) {
 
 function updateTransformations(parentBone, worldPos, averagedDirs, preRotations) {
 
-      var averagedDir = averagedDirs[parentBone.id];
+      const averagedDir = averagedDirs[parentBone.id];
       if (averagedDir) {
 
         //set quaternion
@@ -94,7 +94,7 @@ function updateTransformations(parentBone, worldPos, averagedDirs, preRotations)
         // setQuaternionFromDirection(childBoneDir, Y_AXIS, parentBone.quaternion)
         // console.log('new quaternion', parentBone.quaternion.toArray().join(','));
     }
-    var preRot = preRotations[parentBone.id] || preRotations[parentBone.name];
+    const preRot = preRotations[parentBone.id] || preRotations[parentBone.name];
     if (preRot) parentBone.quaternion.multiply(preRot);
     // parentBone.quaternion.multiply(new Quaternion().setFromAxisAngle(new Vector3(0, 1, 0), Math.PI));
     parentBone.updateMatrixWorld();
@@ -102,7 +102,7 @@ function updateTransformations(parentBone, worldPos, averagedDirs, preRotations)
     //set child bone position relative to the new parent matrix.
     const childBones = parentBone.children.filter(c => c.isBone);
     childBones.forEach((childBone) => {
-      var childBonePosWorld = worldPos[childBone.id][0].clone();
+      const childBonePosWorld = worldPos[childBone.id][0].clone();
       parentBone.worldToLocal(childBonePosWorld);
       childBone.position.copy(childBonePosWorld);
     });
@@ -149,7 +149,7 @@ function setQuaternionFromDirection(direction, up, target) {
 }
 
 function getOriginalWorldPositions(rootBone, worldPos) {
-  var rootBoneWorldPos = rootBone.getWorldPosition(new Vector3())
+  const rootBoneWorldPos = rootBone.getWorldPosition(new Vector3())
   worldPos[rootBone.id] = [rootBoneWorldPos];
   rootBone.children.forEach((child) => {
     child.isBone && getOriginalWorldPositions(child, worldPos)

--- a/packages/engine/src/xr/systems/IKAvatarSystem.ts
+++ b/packages/engine/src/xr/systems/IKAvatarSystem.ts
@@ -17,7 +17,7 @@ export class Avatar {
   sdkInputs: any;
   inputs: any;
   options: {};
-  debug: boolean = true;
+  debug = true;
   springBoneManager: any;
   lastModelScaleFactor: any;
   model: any;

--- a/packages/server/src/app/channels.ts
+++ b/packages/server/src/app/channels.ts
@@ -5,6 +5,8 @@ import config from '../config';
 import {Application} from '../declarations';
 import getLocalServerIp from '../util/get-local-server-ip';
 import logger from './logger';
+import {localConfig} from "../gameserver/transports/config";
+import {RtpCodecCapability} from "mediasoup/lib/types";
 
 
 let sceneLoaded = false;
@@ -71,6 +73,14 @@ export default (app: Application): void => {
                             console.log('Creating new instance:');
                             console.log(newInstance);
                             const instanceResult = await app.service('instance').create(newInstance);
+                            if ((app as any).isChannelInstance === true) {
+                                const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
+                                const networkTransport = Network.instance.transport as any;
+                                const channelType = 'channel';
+                                if (networkTransport.routers[`${channelType}:${channelId}`] == null)
+                                    networkTransport.routers[`${channelType}:${channelId}`] = await networkTransport.worker.createRouter({ mediaCodecs });
+                                logger.info("Worker created router for channel " + `${channelType}:${channelId}`);
+                            }
                             await agonesSDK.allocate();
                             (app as any).instance = instanceResult;
 

--- a/packages/server/src/gameserver/transports/WebRTCFunctions.ts
+++ b/packages/server/src/gameserver/transports/WebRTCFunctions.ts
@@ -52,7 +52,6 @@ export const sendCurrentProducers = (socket: SocketIO.Socket, channelType: strin
     networkTransport = Network.instance.transport as any;
     const userId = getUserIdFromSocketId(socket.id);
     const selfClient = Network.instance.clients[userId];
-    console.log('sendCurrentProducers being called for ', userId);
     if (selfClient?.socketId != null) {
         Object.entries(Network.instance.clients).forEach(([name, value]) => {
             if (name === userId || value.media == null || value.socketId == null)
@@ -70,7 +69,6 @@ export const sendInitialProducers = async (socket: SocketIO.Socket, channelType:
     networkTransport = Network.instance.transport as any;
     const userId = getUserIdFromSocketId(socket.id);
     const selfClient = Network.instance.clients[userId];
-    console.log('sendInitialProducers being called for ', userId);
     if (selfClient?.socketId != null) {
         Object.entries(Network.instance.clients).forEach(([name, value]) => {
             if (name === userId || value.media == null || value.socketId == null)
@@ -86,7 +84,6 @@ export const sendInitialProducers = async (socket: SocketIO.Socket, channelType:
 export const handleConsumeDataEvent = (socket: SocketIO.Socket) => async (
     dataProducer: DataProducer
 ): Promise<void> => {
-    console.log('handleConsumeData');
     networkTransport = Network.instance.transport as any;
     const userId = getUserIdFromSocketId(socket.id);
     logger.info('Data Consumer being created on server by client: ' + userId);
@@ -170,7 +167,6 @@ export async function closeConsumer(consumer): Promise<void> {
 
 export async function createWebRtcTransport({ peerId, direction, sctpCapabilities, channelType, channelId }: WebRtcTransportParams): Promise<WebRtcTransport> {
     networkTransport = Network.instance.transport as any;
-    console.log("Creating Mediasoup transport for ", channelType, channelId);
     const { listenIps, initialAvailableOutgoingBitrate } = localConfig.mediasoup.webRtcTransport;
     const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
     if (channelType !== 'instance') {
@@ -406,13 +402,13 @@ export async function handleWebRtcReceiveTrack(socket, data, callback): Promise<
             closeConsumer(consumer);
         });
         consumer.on('producerpause', () => {
-            console.log('producerpause for', consumer.id);
-            console.log(consumer);
+            logger.info('producerpause for', consumer.id);
+            logger.info(consumer);
             if (consumer && typeof consumer.pause === 'function') consumer.pause();
             socket.emit(MessageTypes.WebRTCPauseConsumer.toString(), consumer.id);
         });
         consumer.on('producerresume', () => {
-            console.log('producerresume for', consumer.id);
+            logger.info('producerresume for', consumer.id);
             if (consumer && typeof consumer.resume === 'function') consumer.resume();
             socket.emit(MessageTypes.WebRTCResumeConsumer.toString(), consumer.id);
         });
@@ -457,7 +453,6 @@ export async function handleWebRtcPauseConsumer(socket, data, callback): Promise
 }
 
 export async function handleWebRtcResumeConsumer(socket, data, callback): Promise<any> {
-    console.log('resume consumer', data.consumerId);
     const { consumerId } = data,
         consumer = MediaStreamSystem.instance?.consumers.find(c => c.id === consumerId);
     if (consumer != null) {
@@ -488,7 +483,6 @@ export async function handleWebRtcResumeProducer(socket, data, callback): Promis
     const { producerId } = data,
         producer = MediaStreamSystem.instance?.producers.find(p => p.id === producerId);
     logger.info("resume-producer", producer.appData);
-    console.log('Resume-producer for user ' + userId);
     if (producer != null) {
         await producer.resume();
         if (userId != null && Network.instance.clients[userId] != null) {
@@ -509,7 +503,6 @@ export async function handleWebRtcPauseProducer(socket, data, callback): Promise
         producer = MediaStreamSystem.instance?.producers.find(p => p.id === producerId);
     if (producer != null) {
         await producer.pause();
-        console.log('Pause-producer for user ' + userId);
         if (userId != null && Network.instance.clients[userId] != null && Network.instance.clients[userId].media[producer.appData.mediaTag] != null) {
             Network.instance.clients[userId].media[producer.appData.mediaTag].paused = true;
             Network.instance.clients[userId].media[producer.appData.mediaTag].globalMute = globalMute || false;
@@ -527,7 +520,6 @@ export async function handleWebRtcPauseProducer(socket, data, callback): Promise
 export async function handleWebRtcRequestCurrentProducers(socket, data, callback): Promise<any> {
     const { channelType, channelId } = data;
 
-    console.log('requestCurrentProducers', channelType, channelId);
     await sendInitialProducers(socket, channelType, channelId);
     callback({requested: true});
 }

--- a/packages/server/src/hooks/send-invite.ts
+++ b/packages/server/src/hooks/send-invite.ts
@@ -118,12 +118,9 @@ export default () => {
       const inviteType = result.inviteType;
       const targetObjectId = result.targetObjectId;
 
-      console.log('targetObjectId: ' + targetObjectId);
-
       const authProvider = extractLoggedInUserFromParams(params);
       const authUser = await app.service('user').get(authProvider.userId);
 
-      console.log(result.identityProviderType);
       if (result.identityProviderType === 'email') {
         await generateEmail(
           app,
@@ -167,9 +164,6 @@ export default () => {
           }
         });
 
-        console.log('EMAILIDENTITYPROVIDER');
-        console.log(emailIdentityProviderResult);
-
         if (emailIdentityProviderResult.total > 0) {
           await generateEmail(
             app,
@@ -186,9 +180,6 @@ export default () => {
               type: 'sms'
             }
           });
-
-          console.log('SMSIDENTITYPROVIDER');
-          console.log(SMSIdentityProviderResult);
 
           if (SMSIdentityProviderResult.total > 0) {
             await generateSMS(

--- a/packages/server/src/services/accept-invite/accept-invite.service.ts
+++ b/packages/server/src/services/accept-invite/accept-invite.service.ts
@@ -26,7 +26,6 @@ declare module '../../declarations' {
  */
 
 function redirect (req, res, next): any {
-  console.log('REDIRECTING');
   return res.redirect(config.client.url);
 }
 

--- a/packages/server/src/services/comments-fires/comments-fires.class.ts
+++ b/packages/server/src/services/comments-fires/comments-fires.class.ts
@@ -19,7 +19,7 @@ export class CommentsFire extends Service {
   }
 
 
-  async create (data : any, params?:Params): Promise<any> {
+  async create (data: any, params?: Params): Promise<any> {
     const loggedInUser = extractLoggedInUserFromParams(params);
     if (!loggedInUser.userId) {
       return Promise.reject(new BadRequest('Could not add fire. Users isn\'t logged in! '));
@@ -30,7 +30,7 @@ export class CommentsFire extends Service {
 
   }
 
-  async remove ( commentId: string,  params?:Params): Promise<any> {
+  async remove ( commentId: string,  params?: Params): Promise<any> {
     const loggedInUser = extractLoggedInUserFromParams(params);
     if (!loggedInUser.userId) {
       return Promise.reject(new BadRequest('Could not remove fire. Users isn\'t logged in! '));

--- a/packages/server/src/services/comments/comments.class.ts
+++ b/packages/server/src/services/comments/comments.class.ts
@@ -30,11 +30,11 @@ export class Comments extends Service {
       const loggedInUser = extractLoggedInUserFromParams(params);
 
       let select = ` SELECT comments.*, user.id as userId, user.name as userName, COUNT(cf.id) as fires `;
-      let from = ` FROM \`comments\` as comments`;
+      const from = ` FROM \`comments\` as comments`;
       let join = ` JOIN \`user\` as user ON user.id=comments.authorId
                     LEFT JOIN \`comments_fires\` as cf ON cf.commentId=comments.id `;
-      let where = ` WHERE comments.feedId=:feedId `;
-      let order = ` GROUP BY comments.id
+      const where = ` WHERE comments.feedId=:feedId `;
+      const order = ` GROUP BY comments.id
       ORDER BY comments.createdAt DESC    
       LIMIT :skip, :limit`;
       const queryParamsReplacements = {
@@ -71,7 +71,7 @@ export class Comments extends Service {
             text:comment.text,
             fires: comment.fires,
             isFired:comment.fired ? true : false
-        }  
+        };  
       });
       const feedsResult = {
         data,
@@ -85,7 +85,7 @@ export class Comments extends Service {
 
 
 
-    async create (data : any, params?:Params ): Promise<any> {
+    async create (data: any, params?: Params ): Promise<any> {
       const loggedInUser = extractLoggedInUserFromParams(params);
       const {comments:commentsModel, user:userModel} = this.app.get('sequelizeClient').models;
       const newComment =  await commentsModel.create({feedId:data.feedId, authorId:loggedInUser.userId, text: data.text});

--- a/packages/server/src/services/feed-bookmark/feed-bookmark.class.ts
+++ b/packages/server/src/services/feed-bookmark/feed-bookmark.class.ts
@@ -18,7 +18,7 @@ export class FeedBookmark extends Service {
     this.app = app;
   }
 
-  async create (data : any, params?:Params): Promise<any> {
+  async create (data: any, params?: Params): Promise<any> {
     const loggedInUser = extractLoggedInUserFromParams(params);
     if (!loggedInUser?.userId) {
       return Promise.reject(new BadRequest('Could not create bookmark. Users isn\'t logged in! '));
@@ -29,7 +29,7 @@ export class FeedBookmark extends Service {
   }
 
 
-  async remove ( feedId: string,  params?:Params): Promise<any> {
+  async remove ( feedId: string,  params?: Params): Promise<any> {
     const loggedInUser = extractLoggedInUserFromParams(params);
     if (!loggedInUser?.userId) {
       return Promise.reject(new BadRequest('Could not remove bookmark. Users isn\'t logged in! '));

--- a/packages/server/src/services/feed-fires/feed-fires.class.ts
+++ b/packages/server/src/services/feed-fires/feed-fires.class.ts
@@ -59,7 +59,7 @@ export class FeedFires extends Service {
             name: user.name,
             username: user.name,
             verified : true,
-        }  
+        };  
       });
       const feedsResult = {
         data,
@@ -71,7 +71,7 @@ export class FeedFires extends Service {
       return feedsResult;
     }
 
-  async create (data : any, params?:Params): Promise<any> {
+  async create (data: any, params?: Params): Promise<any> {
     const loggedInUser = extractLoggedInUserFromParams(params);
     if (!loggedInUser?.userId) {
       return Promise.reject(new BadRequest('Could not add fire. Users isn\'t logged in! '));
@@ -82,7 +82,7 @@ export class FeedFires extends Service {
 
   }
 
-  async remove ( feedId: string,  params?:Params): Promise<any> {
+  async remove ( feedId: string,  params?: Params): Promise<any> {
     const loggedInUser = extractLoggedInUserFromParams(params);
     if (!loggedInUser?.userId) {
       return Promise.reject(new BadRequest('Could not remove fire. Users isn\'t logged in! '));

--- a/packages/server/src/services/feed/feed.class.ts
+++ b/packages/server/src/services/feed/feed.class.ts
@@ -77,11 +77,11 @@ export class Feed extends Service {
     const loggedInUser = extractLoggedInUserFromParams(params);
 
     let select = `SELECT feed.*, user.id as userId, user.name as userName, COUNT(ff.id) as fires `;
-    let from = ` FROM \`feed\` as feed`;
+    const from = ` FROM \`feed\` as feed`;
     let join = ` JOIN \`user\` as user ON user.id=feed.authorId
                   LEFT JOIN \`feed_fires\` as ff ON ff.feedId=feed.id `;
-    let where = ` WHERE 1`;
-    let order = ` GROUP BY feed.id
+    const where = ` WHERE 1`;
+    const order = ` GROUP BY feed.id
     ORDER BY feed.createdAt DESC    
     LIMIT :skip, :limit `;
     const queryParamsReplacements = {
@@ -223,7 +223,7 @@ export class Feed extends Service {
       return newFeed;
     }
 
-    async create (data : any,  params?: Params): Promise<any> {
+    async create (data: any,  params?: Params): Promise<any> {
       const {feed:feedModel} = this.app.get('sequelizeClient').models;
       const loggedInUser = extractLoggedInUserFromParams(params);
       data.authorId = loggedInUser?.userId;

--- a/packages/server/src/services/instance-provision/instance-provision.class.ts
+++ b/packages/server/src/services/instance-provision/instance-provision.class.ts
@@ -134,8 +134,6 @@ export class InstanceProvision implements ServiceMethods<Data> {
   async find (params?: Params): Promise<any> {
     try {
       let userId;
-      console.log('INCOMING QUERY');
-      console.log(params.query);
       const locationId = params.query.locationId;
       const instanceId = params.query.instanceId;
       const channelId = params.query.channelId;
@@ -201,7 +199,6 @@ export class InstanceProvision implements ServiceMethods<Data> {
         // trying to go to the scene their party is in.
         // If the user is going to a different scene, they will be removed from the party and sent to a random instance
         if (user.partyId) {
-          console.log('Joining party\'s instance');
           const partyOwnerResult = await this.app.service('party-user').find({
             query: {
               partyId: user.partyId,
@@ -220,8 +217,6 @@ export class InstanceProvision implements ServiceMethods<Data> {
                 return getLocalServerIp();
               }
               const addressSplit = partyInstance.ipAddress.split(':');
-              console.log('addressSplit:');
-              console.log(addressSplit);
               return {
                 ipAddress: addressSplit[0],
                 port: addressSplit[1]
@@ -245,8 +240,6 @@ export class InstanceProvision implements ServiceMethods<Data> {
                 return getLocalServerIp();
               }
               const addressSplit = partyInstance.ipAddress.split(':');
-              console.log('addressSplit:');
-              console.log(addressSplit);
               return {
                 ipAddress: addressSplit[0],
                 port: addressSplit[1]

--- a/packages/server/src/services/instance-provision/instance-provision.service.ts
+++ b/packages/server/src/services/instance-provision/instance-provision.service.ts
@@ -44,7 +44,6 @@ export default (app: Application): any => {
    */
   service.publish('created', async (data): Promise<any> => {
     try {
-      console.log('Publishing instance-provision created to ' + data.userId);
       return app.channel(`userIds/${data.userId}`).send({
         ipAddress: data.ipAddress,
         port: data.port,


### PR DESCRIPTION
On some occasions, group/friend/party chat was not connecting a second user to
the first's producers. This ended up being due to how Mediasoup routers were being created.
An instance router is made at GS startup, but GS code was waiting until a transport was
being created to make a router for a channel. If requests to make send and receive transports
came it at basically the same time, both were resulting in router creation, but one was getting
overwritten by the other, leading future consumers to be trying to consumer a different router,
which can't happen.

Channel router is now created when a GS is being initialized as a channel instance server, well before
transport creation. Creating router if it doesn't exist on transport creation was left as-is as a fallback.

Fixed bug where initial channel self-user window wasn't rendering as a 'single' since layerUsers.length
was undefined instead of a number.

Removed a lot of seemingly-unnecessary console.logs.