### PR TITLE
AnimationManager instance auto-creation by getter

### DIFF
--- a/packages/engine/src/templates/character/prefabs/NetworkPlayerCharacter.ts
+++ b/packages/engine/src/templates/character/prefabs/NetworkPlayerCharacter.ts
@@ -54,7 +54,13 @@ import { NamePlateComponent } from '../components/NamePlateComponent';
 
 
 export class AnimationManager {
-	static instance: AnimationManager = new AnimationManager();
+	static _instance: AnimationManager;
+	static get instance() {
+		if (!this._instance) {
+			this._instance = new AnimationManager();
+		}
+		return this._instance;
+	}
 	public initialized = false
 
 	_animations: AnimationClip[] = []


### PR DESCRIPTION
constructing AnimationManager instance in static property triggers Animations.glb loading from AnimationManager.constructor > this.getAnimations, when we just import that AnimationManager module. So i moved instance construction into getter.