### PR TITLE
nodemon-webpack-plugin

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -34,8 +34,8 @@
   "jest": "ts-jest",
   "scripts": {
     "start": "yarn run build && node dist/server.js",
-    "dev": "cross-env NODE_ENV=development concurrently \"webpack --watch --mode=development\" \"nodemon --inspect dist/server.js -w dist\"",
-    "dev-reinit-db": "cross-env NODE_ENV=development FORCE_DB_REFRESH=true concurrently \"webpack --watch --mode=development\" \"nodemon --inspect dist/server.js -w dist\"",
+    "dev": "cross-env NODE_ENV=development webpack --watch --mode=development",
+    "dev-reinit-db": "cross-env NODE_ENV=development FORCE_DB_REFRESH=true  webpack --watch --mode=development",
     "build": "cross-env NODE_ENV=production webpack --mode=production",
     "copyfiles-server": "copyfiles -u 2 src/email-templates/**/* lib/email-templates",
     "test": "echo \"TODO: no test specified\" && exit 0",
@@ -177,6 +177,7 @@
     "feathers-cli": "^2.4.0",
     "no-master-commits": "^1.1.1",
     "nodemon": "^2.0.5",
+    "nodemon-webpack-plugin": "^4.4.4",
     "ts-loader": "^8.0.5",
     "typedoc": "^0.20.16",
     "typescript": "^4.0.3",

--- a/packages/server/webpack.config.js
+++ b/packages/server/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const packageRoot = require('app-root-path').path;
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+const NodemonPlugin = require('nodemon-webpack-plugin');
 
 const root = [path.resolve(__dirname)];
 const plugins = [new ForkTsCheckerWebpackPlugin({
@@ -11,6 +12,28 @@ const plugins = [new ForkTsCheckerWebpackPlugin({
         }
     }
 })];
+
+if (process.env.NODE_ENV !== 'production') {
+    plugins.push(new NodemonPlugin({
+        // What to watch.
+        watch: `${root}/dist`,
+
+        // Arguments to pass to the script being watched.
+        args: [],
+
+        // Node arguments.
+        nodeArgs: ['--inspect'],
+
+        // Files to ignore.
+        ignore: ['*.js.map'],
+
+        // Extensions to watch.
+        ext: 'js',
+
+        // Detailed log.
+        verbose: true,
+    }));
+}
 
 module.exports = {
     entry: `${root}/src/index.ts`,


### PR DESCRIPTION
concurrent run of webpack with nodemon can cause two server starts, one with old "dist/server.js" and then when webpack output is done.