### PR TITLE
Fixed some Harmony/AV bugs.

### DIFF
--- a/packages/client-core/components/ui/Drawer/Right/Right.module.scss
+++ b/packages/client-core/components/ui/Drawer/Right/Right.module.scss
@@ -73,6 +73,20 @@
     }
 }
 
+.invite {
+    [class*='MuiListItemText-root'] {
+        word-break: break-word !important;
+
+        span {
+            font-size: 14px;
+        }
+    }
+
+    button {
+        margin: 0 5px;
+    }
+}
+
 .invite-text {
     fieldset {
         border-color: rgba(40, 40, 40, 0.8);

--- a/packages/client-core/components/ui/Drawer/Right/index.tsx
+++ b/packages/client-core/components/ui/Drawer/Right/index.tsx
@@ -327,6 +327,7 @@ const Invites = (props: Props): any => {
                     setTabIndex(0);
                 }}
                 onOpen={() => {
+                    setInviteTabIndex(0);
                 }}
             >
                 <Accordion className={styles.rightDrawerAccordion} expanded={selectedAccordion === 'invite'} onChange={handleAccordionSelect('invite')}>
@@ -369,17 +370,15 @@ const Invites = (props: Props): any => {
                                 {inviteTabIndex === 1 && receivedInvites.sort((a, b) => {
                                     return a.created - b.created;
                                 }).map((invite, index) => {
-                                    return <div key={invite.id}>
+                                    return <div className={styles.invite} key={invite.id}>
                                         <ListItem>
                                             <ListItemAvatar>
                                                 <Avatar src={invite.user.avatarUrl}/>
                                             </ListItemAvatar>
                                             {invite.inviteType === 'friend' &&
-                                            <ListItemText>{capitalize(invite.inviteType)} request
-                                                from {invite.user.name}</ListItemText>}
+                                            <ListItemText>{capitalize(invite.inviteType)} request from {invite.user.name}</ListItemText>}
                                             {invite.inviteType === 'group' &&
-                                            <ListItemText>Join
-                                                group {invite.groupName} from {invite.user.name}</ListItemText>}
+                                            <ListItemText>Join group {invite.groupName} from {invite.user.name}</ListItemText>}
                                             {invite.inviteType === 'party' &&
                                             <ListItemText>Join a party from {invite.user.name}</ListItemText>}
                                             <Button
@@ -404,7 +403,7 @@ const Invites = (props: Props): any => {
                                 {inviteTabIndex === 2 && sentInvites.sort((a, b) => {
                                     return a.created - b.created;
                                 }).map((invite, index) => {
-                                    return <div key={invite.id}>
+                                    return <div className={styles.invite}  key={invite.id}>
                                         <ListItem>
                                             <ListItemAvatar>
                                                 <Avatar src={invite.user.avatarUrl}/>

--- a/packages/client-core/components/ui/PartyParticipantWindow/index.tsx
+++ b/packages/client-core/components/ui/PartyParticipantWindow/index.tsx
@@ -191,18 +191,11 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
     }, [selfUser]);
 
     useEffect(() => {
-        if ((Network.instance?.transport as any)?.channelType === 'instance') {
-            (Network.instance?.transport as any)?.instanceSocket?.on(MessageTypes.WebRTCPauseConsumer.toString(), pauseConsumerListener);
-            (Network.instance?.transport as any)?.instanceSocket?.on(MessageTypes.WebRTCResumeConsumer.toString(), resumeConsumerListener);
-            (Network.instance?.transport as any)?.instanceSocket?.on(MessageTypes.WebRTCPauseProducer.toString(), pauseProducerListener);
-            (Network.instance?.transport as any)?.instanceSocket?.on(MessageTypes.WebRTCResumeProducer.toString(), resumeProducerListener);
-        }
-        else {
-            (Network.instance?.transport as any)?.channelSocket?.on(MessageTypes.WebRTCPauseConsumer.toString(), pauseConsumerListener);
-            (Network.instance?.transport as any)?.channelSocket?.on(MessageTypes.WebRTCResumeConsumer.toString(), resumeConsumerListener);
-            (Network.instance?.transport as any)?.channelSocket?.on(MessageTypes.WebRTCPauseProducer.toString(), pauseProducerListener);
-            (Network.instance?.transport as any)?.channelSocket?.on(MessageTypes.WebRTCResumeProducer.toString(), resumeProducerListener);
-        }
+        const socket = (Network.instance?.transport as any)?.channelType === 'instance' ? (Network.instance?.transport as any)?.instanceSocket : (Network.instance?.transport as any)?.channelSocket;
+        socket?.on(MessageTypes.WebRTCPauseConsumer.toString(), pauseConsumerListener);
+        socket?.on(MessageTypes.WebRTCResumeConsumer.toString(), resumeConsumerListener);
+        socket?.on(MessageTypes.WebRTCPauseProducer.toString(), pauseProducerListener);
+        socket?.on(MessageTypes.WebRTCResumeProducer.toString(), resumeProducerListener);
     }, []);
 
     useEffect(() => {
@@ -244,6 +237,7 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
                 const updateVideoTrackClones = videoTrackClones.concat(newVideoTrack);
                 setVideoTrackClones(updateVideoTrackClones);
                 videoRef.current.srcObject = new MediaStream([newVideoTrack]);
+                setVideoProducerPaused(false);
             }
         }
 
@@ -254,7 +248,7 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
 
     useEffect(() => {
         if (peerId === 'me_cam' || peerId === 'me_screen') setAudioStreamPaused(MediaStreamSystem.instance?.audioPaused);
-        if (audioStream != null && audioRef.current != null) {
+        if (harmony === true && audioStream != null && audioRef.current != null) {
             const newAudioTrack = audioStream.track.clone();
             const updateAudioTrackClones = audioTrackClones.concat(newAudioTrack);
             setAudioTrackClones(updateAudioTrackClones);
@@ -264,7 +258,7 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
 
     useEffect(() => {
         if (peerId === 'me_cam' || peerId === 'me_screen') setVideoStreamPaused(MediaStreamSystem.instance?.videoPaused);
-        if (videoStream != null && videoRef.current != null) {
+        if (harmony === true && videoStream != null && videoRef.current != null) {
             const newVideoTrack = videoStream.track.clone();
             const updateVideoTrackClones = videoTrackClones.concat(newVideoTrack);
             setVideoTrackClones(updateVideoTrackClones);
@@ -335,6 +329,7 @@ const PartyParticipantWindow = (props: Props): JSX.Element => {
     const togglePiP = () => setPiP(!isPiP);
 
     const isSelfUser = peerId === 'me_cam' || peerId === 'me_screen';
+
     return (
         <Draggable isPiP={isPiP}>
         <div

--- a/packages/engine/src/networking/classes/SocketWebRTCClientTransport.ts
+++ b/packages/engine/src/networking/classes/SocketWebRTCClientTransport.ts
@@ -226,11 +226,11 @@ export class SocketWebRTCClientTransport implements NetworkTransport {
           // (MediaStreamSystem.mediaStream !== null) &&
           (producerId != null) &&
           (channelType === self.channelType) &&
-          (selfProducerIds.indexOf(producerId) < 0) &&
-          (MediaStreamSystem.instance?.consumers?.find(
-            c => c?.appData?.peerId === socketId && c?.appData?.mediaTag === mediaTag
-          ) == null /*&&
-            (channelType === 'instance' ? this.channelType === 'instance' : this.channelType === channelType && this.channelId === channelId)*/)
+          (selfProducerIds.indexOf(producerId) < 0)
+          // (MediaStreamSystem.instance?.consumers?.find(
+          //   c => c?.appData?.peerId === socketId && c?.appData?.mediaTag === mediaTag
+          // ) == null /*&&
+          //   (channelType === 'instance' ? this.channelType === 'instance' : this.channelType === channelType && this.channelId === channelId)*/)
         ) {
           // that we don't already have consumers for...
           await subscribeToTrack(socketId, mediaTag, channelType, channelId);

--- a/packages/engine/src/networking/enums/MessageTypes.ts
+++ b/packages/engine/src/networking/enums/MessageTypes.ts
@@ -29,6 +29,7 @@ export enum MessageTypes {
   Ban = 27,
   ConnectToWorld = 28,
   WebRTCRequestCurrentProducers = 29,
+  InitializeRouter = 30,
   Synchronization = 100,
   ClientInput = 101,
   StateUpdate = 102,

--- a/packages/engine/src/networking/functions/SocketWebRTCClientFunctions.ts
+++ b/packages/engine/src/networking/functions/SocketWebRTCClientFunctions.ts
@@ -45,102 +45,117 @@ export async function createTransport(direction: string, channelType?: string, c
     let transport;
 
     console.log('Requesting transport creation', direction, channelType, channelId);
-    const { transportOptions } = await request(MessageTypes.WebRTCTransportCreate.toString(), { direction, sctpCapabilities: networkTransport.mediasoupDevice.sctpCapabilities, channelType: channelType, channelId: channelId });
+    if (request != null) {
+        const {transportOptions} = await request(MessageTypes.WebRTCTransportCreate.toString(), {
+            direction,
+            sctpCapabilities: networkTransport.mediasoupDevice.sctpCapabilities,
+            channelType: channelType,
+            channelId: channelId
+        });
 
-    if (direction === "recv")
-        transport = await networkTransport.mediasoupDevice.createRecvTransport(transportOptions);
-    else if (direction === "send")
-        transport = await networkTransport.mediasoupDevice.createSendTransport(transportOptions);
-    else
-        throw new Error(`bad transport 'direction': ${direction}`);
+        if (direction === "recv")
+            transport = await networkTransport.mediasoupDevice.createRecvTransport(transportOptions);
+        else if (direction === "send")
+            transport = await networkTransport.mediasoupDevice.createSendTransport(transportOptions);
+        else
+            throw new Error(`bad transport 'direction': ${direction}`);
 
-    // mediasoup-client will emit a connect event when media needs to
-    // start flowing for the first time. send dtlsParameters to the
-    // server, then call callback() on success or errback() on failure.
-    transport.on("connect", async ({ dtlsParameters }: any, callback: () => void, errback: () => void) => {
-        const connectResult = await request(MessageTypes.WebRTCTransportConnect.toString(),
-            { transportId: transportOptions.id, dtlsParameters });
+        // mediasoup-client will emit a connect event when media needs to
+        // start flowing for the first time. send dtlsParameters to the
+        // server, then call callback() on success or errback() on failure.
+        transport.on("connect", async ({dtlsParameters}: any, callback: () => void, errback: () => void) => {
+            const connectResult = await request(MessageTypes.WebRTCTransportConnect.toString(),
+                {transportId: transportOptions.id, dtlsParameters});
 
-        if (connectResult.error) {
-            console.log('Transport connect error');
-            console.log(connectResult.error);
-            return errback();
-        }
-
-        callback();
-    });
-
-    if (direction === "send") {
-        // sending transports will emit a produce event when a new track
-        // needs to be set up to start sending. the producer's appData is
-        // passed as a parameter
-        transport.on("produce",
-            async ({ kind, rtpParameters, appData }: any, callback: (arg0: { id: any; }) => void, errback: () => void) => {
-
-                // we may want to start out paused (if the checkboxes in the ui
-                // aren't checked, for each media type. not very clean code, here
-                // but, you know, this isn't a real application.)
-                let paused = false;
-                if (appData.mediaTag === "cam-video")
-                    paused = MediaStreamSystem.instance.videoPaused;
-                else if (appData.mediaTag === "cam-audio")
-                    paused = MediaStreamSystem.instance.audioPaused;
-
-                // tell the server what it needs to know from us in order to set
-                // up a server-side producer object, and get back a
-                // producer.id. call callback() on success or errback() on
-                // failure.
-                const { error, id } = await request(MessageTypes.WebRTCSendTrack.toString(), {
-                    transportId: transportOptions.id,
-                    kind,
-                    rtpParameters,
-                    paused,
-                    appData
-                });
-                if (error) {
-                    errback();
-                    console.log(error);
-                    return;
-                }
-                callback({ id });
-            });
-
-        transport.on("producedata",
-            async (parameters: any, callback: (arg0: { id: any; }) => void, errback: () => void) => {
-                const { sctpStreamParameters, label, protocol, appData } = parameters;
-                const { error, id } = await request(MessageTypes.WebRTCProduceData, {
-                    transportId: transport.id,
-                    sctpStreamParameters,
-                    label,
-                    protocol,
-                    appData
-                });
-
-                if (error) {
-                    console.log(error);
-                    errback();
-                    return;
-                }
-
-                return callback({ id });
+            if (connectResult.error) {
+                console.log('Transport connect error');
+                console.log(connectResult.error);
+                return errback();
             }
-        );
+
+            callback();
+        });
+
+        if (direction === "send") {
+            // sending transports will emit a produce event when a new track
+            // needs to be set up to start sending. the producer's appData is
+            // passed as a parameter
+            transport.on("produce",
+                async ({
+                           kind,
+                           rtpParameters,
+                           appData
+                       }: any, callback: (arg0: { id: any; }) => void, errback: () => void) => {
+
+                    // we may want to start out paused (if the checkboxes in the ui
+                    // aren't checked, for each media type. not very clean code, here
+                    // but, you know, this isn't a real application.)
+                    let paused = false;
+                    if (appData.mediaTag === "cam-video")
+                        paused = MediaStreamSystem.instance.videoPaused;
+                    else if (appData.mediaTag === "cam-audio")
+                        paused = MediaStreamSystem.instance.audioPaused;
+
+                    // tell the server what it needs to know from us in order to set
+                    // up a server-side producer object, and get back a
+                    // producer.id. call callback() on success or errback() on
+                    // failure.
+                    const {error, id} = await request(MessageTypes.WebRTCSendTrack.toString(), {
+                        transportId: transportOptions.id,
+                        kind,
+                        rtpParameters,
+                        paused,
+                        appData
+                    });
+                    if (error) {
+                        errback();
+                        console.log(error);
+                        return;
+                    }
+                    callback({id});
+                });
+
+            transport.on("producedata",
+                async (parameters: any, callback: (arg0: { id: any; }) => void, errback: () => void) => {
+                    const {sctpStreamParameters, label, protocol, appData} = parameters;
+                    const {error, id} = await request(MessageTypes.WebRTCProduceData, {
+                        transportId: transport.id,
+                        sctpStreamParameters,
+                        label,
+                        protocol,
+                        appData
+                    });
+
+                    if (error) {
+                        console.log(error);
+                        errback();
+                        return;
+                    }
+
+                    return callback({id});
+                }
+            );
+        }
+
+        // any time a transport transitions to closed,
+        // failed, or disconnected, leave the  and reset
+        transport.on("connectionstatechange", async (state: string) => {
+            if (networkTransport.leaving !== true && (state === "closed" || state === "failed" || state === "disconnected")) {
+                await request(MessageTypes.WebRTCTransportClose.toString(), {transportId: transport.id});
+            }
+            if (networkTransport.leaving !== true && state === 'connected' && transport.direction === 'recv') {
+                await request(MessageTypes.WebRTCRequestCurrentProducers.toString(), {
+                    channelType: channelType,
+                    channelId: channelId
+                });
+            }
+        });
+
+        transport.channelType = channelType;
+        transport.channelId = channelId;
+        return Promise.resolve(transport);
     }
-
-    // any time a transport transitions to closed,
-    // failed, or disconnected, leave the  and reset
-    transport.on("connectionstatechange", async (state: string) => {
-        if (networkTransport.leaving !== true && (state === "closed" || state === "failed" || state === "disconnected")) {
-            await request(MessageTypes.WebRTCTransportClose.toString(), { transportId: transport.id });
-        }
-        if (networkTransport.leaving !== true && state === 'connected' && transport.direction === 'recv') {
-            await request(MessageTypes.WebRTCRequestCurrentProducers.toString(), { channelType: channelType, channelId: channelId });
-        }
-    });
-
-    transport.channelType = channelType;
-    transport.channelId = channelId;
-    return Promise.resolve(transport);
+    else return Promise.resolve();
 }
 
 export async function initReceiveTransport(channelType: string, channelId?: string): Promise<MediaSoupTransport | Error> {
@@ -164,6 +179,16 @@ export async function initSendTransport(channelType: string, channelId?: string)
     return Promise.resolve(newTransport);
 }
 
+export async function initRouter(channelType: string, channelId?: string): Promise<void> {
+    networkTransport = Network.instance.transport as any;
+    const request = channelType === 'instance' ? networkTransport.instanceRequest : networkTransport.channelRequest;
+    await request(MessageTypes.InitializeRouter.toString(), {
+        channelType: channelType,
+        channelId: channelId
+    });
+    return Promise.resolve();
+}
+
 export async function configureMediaTransports(channelType, channelId?: string): Promise<boolean> {
     networkTransport = Network.instance.transport as any;
 
@@ -177,6 +202,7 @@ export async function configureMediaTransports(channelType, channelId?: string):
     }
 
     if (channelType !== 'instance' && (networkTransport.channelSendTransport == null || networkTransport.channelSendTransport.closed === true || networkTransport.channelSendTransport.connectionState === 'disconnected')) {
+      await initRouter(channelType, channelId);
       await Promise.all([initSendTransport(channelType, channelId), initReceiveTransport(channelType, channelId)]);
     }
     return true;
@@ -185,13 +211,16 @@ export async function configureMediaTransports(channelType, channelId?: string):
 export async function createCamVideoProducer(channelType: string, channelId?: string): Promise<void> {
     if (MediaStreamSystem.instance.mediaStream !== null && networkTransport.videoEnabled === true) {
         const transport = channelType === 'instance' ? networkTransport.instanceSendTransport : networkTransport.channelSendTransport;
-        MediaStreamSystem.instance.camVideoProducer = await transport.produce({
-            track: MediaStreamSystem.instance.mediaStream.getVideoTracks()[0],
-            encodings: CAM_VIDEO_SIMULCAST_ENCODINGS,
-            appData: { mediaTag: "cam-video", channelType: channelType, channelId: channelId }
-        });
+        if (transport != null) {
+            MediaStreamSystem.instance.camVideoProducer = await transport.produce({
+                track: MediaStreamSystem.instance.mediaStream.getVideoTracks()[0],
+                encodings: CAM_VIDEO_SIMULCAST_ENCODINGS,
+                appData: {mediaTag: "cam-video", channelType: channelType, channelId: channelId}
+            });
 
-        if (MediaStreamSystem.instance.videoPaused) await MediaStreamSystem.instance?.camVideoProducer.pause();
+            if (MediaStreamSystem.instance.videoPaused) await MediaStreamSystem.instance?.camVideoProducer.pause();
+            else await resumeProducer(MediaStreamSystem.instance.camVideoProducer);
+        }
     }
 }
 
@@ -212,13 +241,16 @@ export async function createCamAudioProducer(channelType: string, channelId?: st
         // same thing for audio, but we can use our already-created
         const transport = channelType === 'instance' ? networkTransport.instanceSendTransport : networkTransport.channelSendTransport;
 
-        // Create a new transport for audio and start producing
-        MediaStreamSystem.instance.camAudioProducer = await transport.produce({
-            track: MediaStreamSystem.instance.mediaStream.getAudioTracks()[0],
-            appData: { mediaTag: "cam-audio", channelType: channelType, channelId: channelId }
-        });
+        if (transport != null) {
+            // Create a new transport for audio and start producing
+            MediaStreamSystem.instance.camAudioProducer = await transport.produce({
+                track: MediaStreamSystem.instance.mediaStream.getAudioTracks()[0],
+                appData: {mediaTag: "cam-audio", channelType: channelType, channelId: channelId}
+            });
 
-        if (MediaStreamSystem.instance.audioPaused) MediaStreamSystem.instance?.camAudioProducer.pause();
+            if (MediaStreamSystem.instance.audioPaused) MediaStreamSystem.instance?.camAudioProducer.pause();
+            else await resumeProducer(MediaStreamSystem.instance.camAudioProducer);
+        }
     }
 }
 
@@ -228,63 +260,39 @@ export async function endVideoChat(options: { leftParty?: boolean, endConsumers?
             networkTransport = Network.instance.transport as any;
             const isInstanceMedia = networkTransport.instanceSocket?.connected === true && (networkTransport.channelId == null || networkTransport.channelId.length === 0);
             const isChannelMedia = networkTransport.channelSocket?.connected === true && networkTransport.channelId != null && networkTransport.channelId.length > 0;
+            const request = isInstanceMedia ? networkTransport.instanceRequest : networkTransport.channelRequest;
             if (MediaStreamSystem.instance?.camVideoProducer) {
-                if (isInstanceMedia)
-                    await networkTransport.instanceRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance?.camVideoProducer.id
-                    });
-                if (isChannelMedia)
-                    await networkTransport.channelRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance?.camVideoProducer.id
-                    });
+                await request(MessageTypes.WebRTCCloseProducer.toString(), {
+                    producerId: MediaStreamSystem.instance?.camVideoProducer.id
+                });
                 await MediaStreamSystem.instance?.camVideoProducer?.close();
             }
 
             if (MediaStreamSystem.instance?.camAudioProducer) {
-                if (isInstanceMedia)
-                    await networkTransport.instanceRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance?.camAudioProducer.id
-                    });
-                if (isChannelMedia)
-                    await networkTransport.channelRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance?.camAudioProducer.id
-                    });
+                await request(MessageTypes.WebRTCCloseProducer.toString(), {
+                    producerId: MediaStreamSystem.instance?.camAudioProducer.id
+                });
                 await MediaStreamSystem.instance?.camAudioProducer?.close();
             }
 
             if (MediaStreamSystem.instance?.screenVideoProducer) {
-                if (isInstanceMedia)
-                    await networkTransport.instanceRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance.screenVideoProducer.id
-                    });
-                if (isChannelMedia)
-                    await networkTransport.channelRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance.screenVideoProducer.id
-                    });
+                await request(MessageTypes.WebRTCCloseProducer.toString(), {
+                    producerId: MediaStreamSystem.instance.screenVideoProducer.id
+                });
                 await MediaStreamSystem.instance.screenVideoProducer?.close();
             }
             if (MediaStreamSystem.instance?.screenAudioProducer) {
-                if (isInstanceMedia)
-                    await networkTransport.instanceRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance.screenAudioProducer.id
-                    });
-                if (isChannelMedia)
-                    await networkTransport.channelRequest(MessageTypes.WebRTCCloseProducer.toString(), {
-                        producerId: MediaStreamSystem.instance.screenAudioProducer.id
-                    });
+                await request(MessageTypes.WebRTCCloseProducer.toString(), {
+                    producerId: MediaStreamSystem.instance.screenAudioProducer.id
+                });
                 await MediaStreamSystem.instance.screenAudioProducer?.close();
             }
 
             if (options?.endConsumers === true) {
                 MediaStreamSystem.instance?.consumers.map(async (c) => {
-                    if (isInstanceMedia)
-                        await networkTransport.instanceRequest(MessageTypes.WebRTCCloseConsumer.toString(), {
-                            consumerId: c.id
-                        });
-                    if (isChannelMedia)
-                        await networkTransport.channelRequest(MessageTypes.WebRTCCloseConsumer.toString(), {
-                            consumerId: c.id
-                        });
+                    await request(MessageTypes.WebRTCCloseConsumer.toString(), {
+                        consumerId: c.id
+                    });
                     await c.close();
                 });
             }
@@ -350,15 +358,10 @@ export async function subscribeToTrack(peerId: string, mediaTag: string, channel
         // Only continue if we have a valid id
         if (consumerParameters?.id == null) return;
 
-        consumer = channelType === 'instance' ?
-            await networkTransport.instanceRecvTransport.consume({
+        const transport = channelType === 'instance' ? networkTransport.instanceRecvTransport : networkTransport.channelRecvTransport;
+        consumer = await transport.consume({
                 ...consumerParameters,
                 appData: {peerId, mediaTag, channelType},
-                paused: true
-            })
-            : await networkTransport.channelRecvTransport.consume({
-                ...consumerParameters,
-                appData: {peerId, mediaTag, channelType, channelId},
                 paused: true
             });
 

--- a/packages/server/src/app/channels.ts
+++ b/packages/server/src/app/channels.ts
@@ -73,14 +73,6 @@ export default (app: Application): void => {
                             console.log('Creating new instance:');
                             console.log(newInstance);
                             const instanceResult = await app.service('instance').create(newInstance);
-                            if ((app as any).isChannelInstance === true) {
-                                const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
-                                const networkTransport = Network.instance.transport as any;
-                                const channelType = 'channel';
-                                if (networkTransport.routers[`${channelType}:${channelId}`] == null)
-                                    networkTransport.routers[`${channelType}:${channelId}`] = await networkTransport.worker.createRouter({ mediaCodecs });
-                                logger.info("Worker created router for channel " + `${channelType}:${channelId}`);
-                            }
                             await agonesSDK.allocate();
                             (app as any).instance = instanceResult;
 

--- a/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
+++ b/packages/server/src/gameserver/transports/SocketWebRTCServerTransport.ts
@@ -35,6 +35,7 @@ import {
     handleWebRtcTransportConnect,
     handleWebRtcTransportCreate,
     handleWebRtcRequestCurrentProducers,
+    handleWebRtcInitializeRouter,
     startWebRTC
 } from './WebRTCFunctions';
 
@@ -243,6 +244,9 @@ export class SocketWebRTCServerTransport implements NetworkTransport {
 
                 socket.on(MessageTypes.WebRTCRequestCurrentProducers.toString(), async (data, callback) =>
                     handleWebRtcRequestCurrentProducers(socket, data, callback));
+
+                socket.on(MessageTypes.InitializeRouter.toString(), async (data, callback) =>
+                    handleWebRtcInitializeRouter(socket, data, callback));
             });
         });
     }

--- a/packages/server/src/gameserver/transports/WebRTCFunctions.ts
+++ b/packages/server/src/gameserver/transports/WebRTCFunctions.ts
@@ -529,3 +529,16 @@ export async function handleWebRtcRequestCurrentProducers(socket, data, callback
     await sendInitialProducers(socket, channelType, channelId);
     callback({requested: true});
 }
+
+export async function handleWebRtcInitializeRouter(socket, data, callback): Promise<any> {
+    const { channelType, channelId } = data;
+    if (channelType !== 'instance') {
+        const mediaCodecs = localConfig.mediasoup.router.mediaCodecs as RtpCodecCapability[];
+        const networkTransport = Network.instance.transport as any;
+        if (networkTransport.routers[`${channelType}:${channelId}`] == null) {
+            console.log('Making new router');
+            networkTransport.routers[`${channelType}:${channelId}`] = await networkTransport.worker.createRouter({mediaCodecs});
+        }
+    }
+    callback({initialized: true});
+}


### PR DESCRIPTION
Prior solution to initializing channel worker didn't solve problem since
instance startup can resolve after first transports have already been made.
Added a new WebRTC message and handler for initializing channel transport,
which client calls and resolves before initializing transports.

Fixed some issues with non-Harmony video feeds flickering when user video
toggled. Prior fix to refresh user video was mistakenly applying to all
videos.

Fixed some bugs related to users turning off video before it has fully started.
Removed subscribeToTrack call's limitation to consumers that don't match any
that a client has; sometimes a client can get stuck with an outdated one from
an incomplete initialization/shutdown, so a new one should override and clear
the old one.

Streamlined some ternary statements for instance/channel requests to just
get the proper request and call it, whatever it is.