### PR TITLE
add Portals, save Colliders 2 ways, spawn point changes

### DIFF
--- a/packages/client-core/components/editor/properties/ModelNodeEditor.tsx
+++ b/packages/client-core/components/editor/properties/ModelNodeEditor.tsx
@@ -62,6 +62,11 @@ export default class ModelNodeEditor extends Component<
     (this.props.editor as any).setPropertySelected("collidable", collidable);
   };
 
+  //function to handle change in saveColliders property
+  onChangeSaveColliders = saveColliders => {
+    (this.props.editor as any).setPropertySelected("saveColliders", saveColliders);
+  };
+
   // function to handle changes in walkable property
   onChangeWalkable = walkable => {
     (this.props.editor as any).setPropertySelected("walkable", walkable);
@@ -230,6 +235,13 @@ export default class ModelNodeEditor extends Component<
           <BooleanInput
             value={node.collidable}
             onChange={this.onChangeCollidable}
+          />
+        </InputGroup>
+        { /* @ts-ignore */ }
+        <InputGroup name="Save Colliders">
+          <BooleanInput
+            value={node.saveColliders}
+            onChange={this.onChangeSaveColliders}
           />
         </InputGroup>
         { /* @ts-ignore */ }

--- a/packages/client-core/components/scenes/location.tsx
+++ b/packages/client-core/components/scenes/location.tsx
@@ -29,6 +29,7 @@ import querystring from 'querystring';
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
+import { useRouter } from 'next/router';
 import url from 'url';
 import { generalStateList, setAppLoaded, setAppOnBoardingStep } from '../../redux/app/actions';
 import { selectAuthState } from '../../redux/auth/selector';
@@ -45,6 +46,7 @@ import TooltipContainer from '../ui/TooltipContainer';
 import { MessageTypes } from '@xr3ngine/engine/src/networking/enums/MessageTypes';
 import { EngineEvents } from '@xr3ngine/engine/src/ecs/classes/EngineEvents';
 import { InteractiveSystem } from '@xr3ngine/engine/src/interaction/systems/InteractiveSystem';
+import { PhysicsSystem } from '@xr3ngine/engine/src/physics/systems/PhysicsSystem';
 import { DefaultInitializationOptions, initializeEngine } from '@xr3ngine/engine/src/initialize';
 
 const goHome = () => window.location.href = window.location.origin;
@@ -113,6 +115,7 @@ export const EnginePage = (props: Props) => {
   const [infoBoxData, setModalData] = useState(null);
   const [userBanned, setUserBannedState] = useState(false);
   const [openLinkData, setOpenLinkData] = useState(null);
+  const router = useRouter();
 
   const [progressEntity, setProgressEntity] = useState(99);
   const [userHovered, setonUserHover] = useState(false);
@@ -204,7 +207,7 @@ export const EnginePage = (props: Props) => {
     }
   }, [appState]);
   const projectRegex = /\/([A-Za-z0-9]+)\/([a-f0-9-]+)$/;
-  
+
   async function init(sceneId: string): Promise<any> { // auth: any,
     let service, serviceId;
     const projectResult = await client.service('project').get(sceneId);
@@ -236,13 +239,15 @@ export const EnginePage = (props: Props) => {
     await initializeEngine(InitializationOptions)
 
     document.dispatchEvent(new CustomEvent('ENGINE_LOADED')); // this is the only time we should use document events. would be good to replace this with react state
-    
+
     EngineEvents.instance.addEventListener(EngineEvents.EVENTS.CONNECT_TO_WORLD, onNetworkConnect);
     EngineEvents.instance.addEventListener(EngineEvents.EVENTS.SCENE_LOADED, onSceneLoaded);
     EngineEvents.instance.addEventListener(EngineEvents.EVENTS.ENTITY_LOADED, onSceneLoadedEntity);
     EngineEvents.instance.addEventListener(InteractiveSystem.EVENTS.USER_HOVER, onUserHover);
     EngineEvents.instance.addEventListener(InteractiveSystem.EVENTS.OBJECT_ACTIVATION, onObjectActivation);
     EngineEvents.instance.addEventListener(InteractiveSystem.EVENTS.OBJECT_HOVER, onObjectHover);
+    EngineEvents.instance.addEventListener(PhysicsSystem.EVENTS.PORTAL_REDIRECT_EVENT, ({ location }) => router.push(location));
+
     const engageType = isMobileOrTablet() ? 'touchstart' : 'click'
     const onUserEngage = () => {
       EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.USER_ENGAGE });

--- a/packages/engine/src/assets/components/AssetLoader.ts
+++ b/packages/engine/src/assets/components/AssetLoader.ts
@@ -15,6 +15,8 @@ export class AssetLoader extends Component<AssetLoader> {
   assetType: AssetTypeAlias = null
   /** Class of the asset. Supported Asset classes can be found in {@link assets/enums/AssetClass.AssetClass | AssetClass}. */
   assetClass: AssetClassAlias = null
+  /** the object will parse to Colliders when loading location */
+  parseColliders = true
   /** Indicates whether the object will receive a shadow. */
   receiveShadow = false
   /** Indicates whether the object will cast a shadow. */
@@ -35,6 +37,7 @@ AssetLoader._schema = {
   assetClass: { default: AssetClass, type: Types.Number },
   url: { default: '', type: Types.Number },
   loaded: { default: false, type: Types.Boolean },
+  parseColliders: { default: true, type: Types.Boolean },
   receiveShadow: { default: false, type: Types.Boolean },
   castShadow: { default: false, type: Types.Boolean },
   envMapOverride: { default: null, type: Types.Ref },

--- a/packages/engine/src/networking/functions/applyNetworkStateToClient.ts
+++ b/packages/engine/src/networking/functions/applyNetworkStateToClient.ts
@@ -146,9 +146,6 @@ export function applyNetworkStateToClient(worldStateBuffer: WorldStateInterface,
                 console.warn('Give Player Id by Server '+objectToCreate.networkId, objectToCreate.ownerId, Network.instance.userId);
                 console.warn(Network.instance.networkObjects);
                 Network.instance.localAvatarNetworkId = objectToCreate.networkId;
-                addComponent(networkObject.entity, InterpolationComponent);
-              } else {
-                addComponent(networkObject.entity, InterpolationComponent);
               }
 
             }

--- a/packages/engine/src/physics/behaviors/addColliderWithoutEntity.ts
+++ b/packages/engine/src/physics/behaviors/addColliderWithoutEntity.ts
@@ -1,9 +1,17 @@
-import { Body, Box, Sphere, Cylinder, Plane, Vec3 } from 'cannon-es';
+import { Body, Trimesh, Box, Sphere, Cylinder, Plane, Vec3 } from 'cannon-es';
 import { PhysicsSystem } from '../systems/PhysicsSystem';
 import { CollisionGroups } from "../enums/CollisionGroups";
 import { threeToCannon } from '../classes/three-to-cannon';
 
-export function createTrimesh (mesh) {
+export function createTrimeshFromArrayVertices (vertices, indices) {
+	  indices = indices || vertices.map((v,i) => i);
+		const shape = new Trimesh(vertices, indices)
+		const body = new Body({ mass: 0 });
+    body.addShape(shape);
+		return body;
+}
+
+export function createTrimeshFromMesh (mesh) {
 		const shape = threeToCannon(mesh, {type: threeToCannon.Type.MESH});
 		const body = new Body({ mass: 0 });
     body.addShape(shape);
@@ -47,8 +55,7 @@ export function doThisActivateCollider (body, userData) {
 	return body;
 }
 
-export function addColliderWithoutEntity( userData, position, quaternion, scale, mesh ) {
-	console.warn('****** Collider '+userData.type);
+export function addColliderWithoutEntity( userData, position, quaternion, scale, { mesh = null, vertices = null, indices = null }) {
   let body;
 	const type = userData.type
   switch (type) {
@@ -74,7 +81,14 @@ export function addColliderWithoutEntity( userData, position, quaternion, scale,
       break;
 
     case 'trimesh':
-      body = createTrimesh(mesh);
+			if (mesh != null) {
+				body = createTrimeshFromMesh(mesh);
+			} else if (vertices != null) {
+				body = createTrimeshFromArrayVertices(vertices, indices);
+			} else {
+				console.warn('!!! dont have any mesh or vertices array to create trimesh');
+				return;
+			}
       break;
 
     default:
@@ -86,7 +100,7 @@ export function addColliderWithoutEntity( userData, position, quaternion, scale,
   if (position) {
     body.position.set(position.x, position.y, position.z);
   }
-  
+
   if (quaternion) {
     body.quaternion.set(quaternion.x, quaternion.y, quaternion.z, quaternion.w);
   }

--- a/packages/engine/src/physics/behaviors/physicsMove.ts
+++ b/packages/engine/src/physics/behaviors/physicsMove.ts
@@ -21,6 +21,7 @@ import { TransformComponent } from '../../transform/components/TransformComponen
 import { isServer } from '../../common/functions/isServer';
 import { LocalInputReceiver } from "../../input/components/LocalInputReceiver";
 import { InterpolationComponent } from '../components/InterpolationComponent';
+import TeleportToSpawnPoint from '../../scene/components/TeleportToSpawnPoint';
 
 const forwardVector = new Vector3(0, 0, 1);
 const upVector = new Vector3(0, 1, 0);
@@ -46,7 +47,7 @@ export const physicsMove: Behavior = (entity: Entity, args: any, deltaTime): voi
     transform.rotation.setFromUnitVectors(forwardVector, actor.orientation.clone().setY(0));
   }
   // if we rotation character here, lets server will do his rotation here too
-  if (hasComponent(entity, InterpolationComponent) && !hasComponent(entity, LocalInputReceiver)) return;
+  if (hasComponent(entity, InterpolationComponent) && !hasComponent(entity, TeleportToSpawnPoint) && !hasComponent(entity, LocalInputReceiver)) return;
   const body = capsule.body;
   // down speed when walk
   if (getComponent(entity, Input).data.get(BaseInput.WALK)?.value === BinaryValue.ON) {

--- a/packages/engine/src/physics/classes/three-to-cannon.ts
+++ b/packages/engine/src/physics/classes/three-to-cannon.ts
@@ -289,7 +289,7 @@ function createTrimeshShape (geometry) {
  * @param {Object3D} object
  * @return {BufferGeometry}
  */
-function getGeometry (object) {
+export function getGeometry (object) {
   let mesh,
       tmp = new BufferGeometry();
   const meshes = getMeshes(object);

--- a/packages/engine/src/physics/components/CapsuleCollider.ts
+++ b/packages/engine/src/physics/components/CapsuleCollider.ts
@@ -14,6 +14,7 @@ export class CapsuleCollider extends Component<CapsuleCollider>
 	public radius: number;
 	public segments: number;
 	public friction: number;
+	public playerStuck: number;
 	public moreRaysIchTurn = 0;
 
 	constructor(options: any)
@@ -82,4 +83,5 @@ CapsuleCollider._schema = {
 	radius: { type: Types.Number, default: 0.3 },
 	segments: { type: Types.Number, default: 8 },
 	friction: { type: Types.Number, default: 0.3 },
+	playerStuck: { type: Types.Number, default: 1000 }
 };

--- a/packages/engine/src/physics/systems/PhysicsSystem.ts
+++ b/packages/engine/src/physics/systems/PhysicsSystem.ts
@@ -53,6 +53,9 @@ const cannonDebugger = isClient ? import('cannon-es-debugger').then((module) => 
 }) : null;
 */
 export class PhysicsSystem extends System {
+  static EVENTS = {
+    PORTAL_REDIRECT_EVENT: 'PHYSICS_SYSTEM_PORTAL_REDIRECT',
+  };
   updateType = SystemUpdateType.Fixed;
   static frame: number
   diffSpeed: number = Engine.physicsFrameRate / Engine.networkFramerate;
@@ -230,7 +233,7 @@ export class PhysicsSystem extends System {
         correction: Vault.instance?.get((Network.instance.snapshot as any).timeCorrection, true),
         new: []
       }
-
+      console.warn(snapshots.correction);
       this.queryResults.serverCorrection.all?.forEach(entity => {
         // Creatr new snapshot position for next frame server correction
         createNewCorrection(entity, {

--- a/packages/engine/src/scene/behaviors/createBoxCollider.ts
+++ b/packages/engine/src/scene/behaviors/createBoxCollider.ts
@@ -7,7 +7,18 @@ import { RigidBody } from '../../physics/components/RigidBody';
 import { addColliderWithoutEntity } from '../../physics/behaviors/addColliderWithoutEntity';
 
 export const createBoxCollider: Behavior = (entity, args: any) => {
-  console.warn(args.objArgs);
-  //addColliderWithoutEntity({type:args.objArgs.type}, args.objArgs.position, args.objArgs.quaternion, args.objArgs.scale, args.objArgs.vertices, args.objArgs.indices);
-  addColliderWithoutEntity({type:args.objArgs.type}, args.objArgs.position, args.objArgs.quaternion, args.objArgs.scale, args.objArgs.mesh);
+  console.log('****** Collider from Scene data, type: '+args.objArgs.type);
+  console.log(args.objArgs);
+
+  addColliderWithoutEntity(
+    {type:args.objArgs.type},
+    args.objArgs.position,
+    args.objArgs.quaternion,
+    args.objArgs.scale,
+    {
+      mesh: args.objArgs.mesh,
+      vertices:  args.objArgs.vertices,
+      indices:   args.objArgs.indices
+    }
+  );
 };

--- a/packages/engine/src/scene/functions/SceneLoading.ts
+++ b/packages/engine/src/scene/functions/SceneLoading.ts
@@ -1,5 +1,6 @@
 import { AssetLoader } from '../../assets/components/AssetLoader';
 import { isClient } from "../../common/functions/isClient";
+import { Engine } from '../../ecs/classes/Engine';
 import { EngineEvents } from '../../ecs/classes/EngineEvents';
 import { Entity } from "../../ecs/classes/Entity";
 import { addComponent, createEntity, getMutableComponent } from '../../ecs/functions/EntityFunctions';
@@ -12,8 +13,8 @@ export function loadScene(scene: SceneData): void {
   const loadPromises = [];
   let loaded = 0;
   if (isClient) {
-    // console.warn(Engine.scene);
-    // console.warn(scene);
+     console.warn(Engine.scene);
+     console.warn(scene);
     EngineEvents.instance.dispatchEvent({ type: EngineEvents.EVENTS.ENTITY_LOADED, left: loadPromises.length });
   }
   Object.keys(scene.entities).forEach(key => {

--- a/packages/engine/src/scene/systems/SpawnSystem.ts
+++ b/packages/engine/src/scene/systems/SpawnSystem.ts
@@ -48,15 +48,17 @@ export class ServerSpawnSystem extends System {
         });
         this.queryResults.toBeSpawned.all?.forEach(entity => {
           const capsule = getMutableComponent(entity, CapsuleCollider);
-            if (capsule.body != null && capsule.playerStuck > 180) {
-                const spawnTransform = getComponent(this.spawnPoints[this.lastSpawnIndex], TransformComponent);
-                capsule.body.position.set(
-                  spawnTransform.position.x,
-                  spawnTransform.position.y,
-                  spawnTransform.position.z
-                );
-                capsule.playerStuck = 0;
-                this.lastSpawnIndex = (this.lastSpawnIndex + 1) % this.spawnPoints.length;
+          const spawnTransform = getComponent(this.spawnPoints[this.lastSpawnIndex], TransformComponent);
+            if (capsule.body != null && capsule.playerStuck > 180 && spawnTransform) {
+
+              this.lastSpawnIndex = (this.lastSpawnIndex + 1) % this.spawnPoints.length;
+              capsule.body.position.set(
+                spawnTransform.position.x,
+                spawnTransform.position.y,
+                spawnTransform.position.z
+              );
+              capsule.playerStuck = 0;
+
             }
         });
         this.queryResults.spawnPoint.removed?.forEach(entity => {

--- a/packages/engine/src/templates/character/components/CharacterComponent.ts
+++ b/packages/engine/src/templates/character/components/CharacterComponent.ts
@@ -96,7 +96,6 @@ export class CharacterComponent extends Component<CharacterComponent> {
 	public raySafeOffset = 0.03;
 	public wantsToJump = false;
 	public initJumpSpeed = -1;
-	public playerStuck = 0;
 	public playerInPortal = 0;
 	public animationVelocity: Vector3 = new Vector3();
 	public groundImpactVelocity: Vector3 = new Vector3();

--- a/packages/engine/src/templates/character/prefabs/NetworkPlayerCharacter.ts
+++ b/packages/engine/src/templates/character/prefabs/NetworkPlayerCharacter.ts
@@ -710,6 +710,8 @@ export const NetworkPlayerCharacter: NetworkPrefab = {
     { type: CharacterComponent, data: { avatarId: DEFAULT_AVATAR_ID }},
     // Transform system applies values from transform component to three.js object (position, rotation, etc)
     { type: TransformComponent },
+		// Its component is a pass to Interpolation for Other Players and Serrver Correction for Your Local Player
+		{ type: InterpolationComponent },
     // Local player input mapped to behaviors in the input map
     { type: Input, data: { schema: CharacterInputSchema } },
     // Current state (isJumping, isidle, etc)
@@ -721,8 +723,7 @@ export const NetworkPlayerCharacter: NetworkPrefab = {
   localClientComponents: [
     { type: LocalInputReceiver },
     { type: FollowCameraComponent, data: { distance: 3, mode: CameraModes.ThirdPerson } },
-    { type: Interactor },
-  	{ type: InterpolationComponent }
+    { type: Interactor }
   ],
   serverComponents: [
     { type: TeleportToSpawnPoint },

--- a/packages/server/src/gameserver/transports/NetworkFunctions.ts
+++ b/packages/server/src/gameserver/transports/NetworkFunctions.ts
@@ -264,10 +264,10 @@ export async function handleJoinWorld(socket, data, callback, userId, user): Pro
     logger.info("JoinWorld received");
     const transport = Network.instance.transport as any;
 
-    const spawnPoint = Engine.spawnSystem.getRandomSpawnPoint();
+  //  const spawnPoint = Engine.spawnSystem.getRandomSpawnPoint();
 
     // Create a new default prefab for client
-    const networkObject = initializeNetworkObject(userId, Network.getNetworkId(), Network.instance.schema.defaultClientPrefab, spawnPoint.position, spawnPoint.rotation);
+    const networkObject = initializeNetworkObject(userId, Network.getNetworkId(), Network.instance.schema.defaultClientPrefab);// , spawnPoint.position, spawnPoint.rotation
     const transform = getComponent(networkObject.entity, TransformComponent);
 
     // Add the network object to our list of network objects


### PR DESCRIPTION
What i do:
- in the editor in the model node, there is a checkmark, saveColliders (this switches two different types of collider loading)
- adjusted the mixing of the rotation position and the scale of the Model + parameters of the editor. For all colliders, and types of creation.
- set up spawn points to work on the server and change not transform, but capsula.body. Without transforming packets, the client character will appear at x0 y0 z0. The server corrects it to spawn point .
(Since this will immediately show whether there is a connection to the server, if the location on the server has not started, we will appear at the 0 coordinate.)
- Correctly added the network correction component to the character prefab.
- Portals works now from model user.data
- if the character is in the fall for some time, server teleports him to the spawn point