### PR TITLE
fix file upload to server

### DIFF
--- a/packages/social/config/default.json
+++ b/packages/social/config/default.json
@@ -8,7 +8,7 @@
     "appServer": "https://127.0.0.1:3000",
     "siteTitle": "ARC",
     "siteDescription": "Connected Worlds for Everyone",
-    "featherStoreKey": "Arc-Auth-Store",
+    "featherStoreKey": "TheOverlay-Auth-Store",
     "localStorageKey": "arc-client-store-key-v1",
     "auth": {
       "enableSmsMagicLink": true,


### PR DESCRIPTION
error was in using own featherStoreKey value, editor /packages/client-core/components/editor/configs uses hardcoded string constant for "non-production" (and even if not - 'editor' value will differ from 'social').
for now just reverted to "TheOverlay-Auth-Store".