### PR TITLE
🐚 Improve start-db.sh

### DIFF
--- a/scripts/start-db.sh
+++ b/scripts/start-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if which docker > /dev/null 2>&1
 then

--- a/scripts/start-db.sh
+++ b/scripts/start-db.sh
@@ -1,5 +1,17 @@
-#!/usr/bin/env bash
-echo -e "\e[32mInitializing mariadb..."
-docker stop xr3ngine
-docker rm xr3ngine
-docker-compose up
+#!/bin/bash
+
+if which docker > /dev/null 2>&1
+then
+    if which docker-compose > /dev/null 2>&1
+    then
+        echo "✅ Docker & Docker-Compose Detected:"
+        echo -e "\e[32m💾 Initializing mariadb docker image..."
+        docker stop xr3ngine
+        docker rm xr3ngine
+        docker-compose up
+    else
+        echo "❌ Please install docker-compose..."
+    fi
+else
+    echo "❌ Please install docker..."
+fi


### PR DESCRIPTION
Validates docker and docker compose are installed. (On linux docker-compose is actually installed seperately).
Returns an appropriate error message if either docker/docker-compose is missing.
Shell script tested for maximum POSIX compatability with 100% of tests passing. (See https://github.com/koalaman/shellcheck).