### PR TITLE
Fixed a few issues relating to tokens expiring.

### DIFF
--- a/packages/client-core/src/user/reducers/auth/service.ts
+++ b/packages/client-core/src/user/reducers/auth/service.ts
@@ -70,7 +70,7 @@ export function doLoginAuto (allowGuest?: boolean, forceClientAuthReset?: boolea
       try {
         res = await (client as any).reAuthenticate();
       } catch(err) {
-        if (err.className === 'not-found') {
+        if (err.className === 'not-found' || (err.className === 'not-authenticated' && err.message === 'jwt expired')) {
           await dispatch(didLogout());
           await (client as any).authentication.reset();
           const newProvider = await client.service('identity-provider').create({

--- a/packages/server-core/src/channels.ts
+++ b/packages/server-core/src/channels.ts
@@ -6,6 +6,7 @@ import config from './appconfig';
 import { Application } from '../declarations';
 import getLocalServerIp from '@xr3ngine/server-core/src/util/get-local-server-ip';
 import logger from '@xr3ngine/server-core/src/logger';
+import { decode } from 'jsonwebtoken';
 
 export default (app: Application): void => {
     if (typeof app.channel !== 'function') {
@@ -168,7 +169,6 @@ export default (app: Application): void => {
                 }
             } catch (err) {
                 logger.error(err);
-                throw err;
             }
         }
     });
@@ -178,7 +178,19 @@ export default (app: Application): void => {
             try {
                 const token = (connection as any).socketQuery?.token;
                 if (token != null) {
-                    const authResult = await app.service('authentication').strategies.jwt.authenticate({accessToken: token}, {});
+                    let authResult;
+                    try {
+                        authResult = await app.service('authentication').strategies.jwt.authenticate({accessToken: token}, {});
+                    } catch(err) {
+                        if (err.code === 401 && err.data.name === 'TokenExpiredError') {
+                            const jwtDecoded = decode(token);
+                            const idProvider = await app.service('identityProvider').get(jwtDecoded.sub);
+                            authResult = {
+                                'identity-provider': idProvider
+                            };
+                        }
+                        else throw err;
+                    }
                     const identityProvider = authResult['identity-provider'];
                     if (identityProvider != null && identityProvider.id != null) {
                         const userId = identityProvider.userId;
@@ -252,7 +264,6 @@ export default (app: Application): void => {
                 }
             } catch (err) {
                 logger.info(err);
-                throw err;
             }
         }
     });


### PR DESCRIPTION
Server-side calls to authenticate tokens on GS (dis)connect throw errors if the token is expired.
On disconnect, would result in not updating tables for user disconnect, so made token expired error
instead use jsonwebtoken.decode to get the identity-provider ID and get the IDProvider manually.

Client was not properly handling invalid token on reAuthenticate. It now logs in as guest.

Removed throwing errors on GS (dis)connect, as that just causes the server to crash, which
probably doesn't help anything.